### PR TITLE
feat: upstream sync 1.0.40-3 + foreground session methods for all 40 SDKs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,10 @@
 - Tests rely on YAML snapshot exchanges under `test/snapshots/` — to add test scenarios, add or edit the appropriate YAML files and update tests.
 - The harness prints `Listening: http://...` — tests parse this URL to configure CLI or proxy.
 
+## Git commit conventions 🚫
+
+- **Do NOT include `Co-authored-by: Copilot` trailers in any commits.** The repo owner does not want AI co-author attribution in the commit history. This applies to all commits — merges, features, fixes, releases, etc.
+
 ## Project-specific conventions & patterns ✅
 
 - Tools: each SDK has helper APIs to expose functions as tools; prefer the language's `DefineTool`/`@define_tool`/`AIFunctionFactory.Create` patterns (see language READMEs).

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # Documentation validation output
 docs/.validation/
 .DS_Store
+
+# Visual Studio
+.vs/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Embed Copilot's agentic workflows in your application - now available in public 
 
 The GitHub Copilot SDK exposes the same engine behind Copilot CLI: a production-tested agent runtime you can invoke programmatically. No need to build your own orchestration - you define agent behavior, Copilot handles planning, tool invocation, file edits, and more.
 
+> ⭐ **If you find this SDK useful, [star the repo](https://github.com/jeremiahjordanisaacson/copilot-sdk-supercharged/stargazers)!** It helps others discover it and keeps us motivated to ship more.
+
 ### Download Stats
 
 > **Trusted by 15,000+ developers globally and growing daily.**

--- a/ada/src/copilot-client.adb
+++ b/ada/src/copilot-client.adb
@@ -336,4 +336,35 @@ package body Copilot.Client is
       return Self.State = Connected;
    end Is_Connected;
 
+   function Get_Foreground_Session_Id
+     (Self : in out Copilot_Client) return String
+   is
+      Resp : constant String :=
+        Send_Request (Self.Conn, "session.getForeground", "{}");
+      Sid  : constant String := Json_Get (Resp, "sessionId");
+   begin
+      return Sid;
+   end Get_Foreground_Session_Id;
+
+   procedure Set_Foreground_Session_Id
+     (Self       : in out Copilot_Client;
+      Session_Id : String)
+   is
+      Params : constant String :=
+        "{""sessionId"":""" & Escape (Session_Id) & """}";
+      Resp   : constant String :=
+        Send_Request (Self.Conn, "session.setForeground", Params);
+      Succ   : constant String := Json_Get (Resp, "success");
+   begin
+      if Succ /= "true" then
+         declare
+            Err : constant String := Json_Get (Resp, "error");
+         begin
+            raise Protocol_Error
+              with "Failed to set foreground session: "
+                 & (if Err'Length > 0 then Err else "Unknown error");
+         end;
+      end if;
+   end Set_Foreground_Session_Id;
+
 end Copilot.Client;

--- a/ada/src/copilot-client.ads
+++ b/ada/src/copilot-client.ads
@@ -91,6 +91,16 @@ package Copilot.Client is
    --  Return True when the client has an active connection.
    function Is_Connected (Self : Copilot_Client) return Boolean;
 
+   --  Get the foreground session ID. Returns empty string if none.
+   function Get_Foreground_Session_Id
+     (Self : in out Copilot_Client) return String;
+
+   --  Set the foreground session ID.
+   --  Raises Protocol_Error if the server reports failure.
+   procedure Set_Foreground_Session_Id
+     (Self       : in out Copilot_Client;
+      Session_Id : String);
+
 private
 
    type Copilot_Client is tagged record

--- a/c/include/copilot/copilot.h
+++ b/c/include/copilot/copilot.h
@@ -777,6 +777,30 @@ copilot_error_t copilot_client_delete_session(
     const char *session_id
 );
 
+/**
+ * Gets the foreground session ID.
+ *
+ * @param client  The client.
+ * @param out     Output: session ID string. Caller must free().
+ * @return COPILOT_OK on success.
+ */
+copilot_error_t copilot_client_get_foreground_session_id(
+    copilot_client_t *client,
+    char **out
+);
+
+/**
+ * Sets the foreground session ID.
+ *
+ * @param client      The client.
+ * @param session_id  The session ID to set as foreground.
+ * @return COPILOT_OK on success.
+ */
+copilot_error_t copilot_client_set_foreground_session_id(
+    copilot_client_t *client,
+    const char *session_id
+);
+
 /* ============================================================================
  * Session API
  * ============================================================================ */

--- a/c/src/client.c
+++ b/c/src/client.c
@@ -1432,6 +1432,62 @@ copilot_error_t copilot_client_delete_session(
     return COPILOT_OK;
 }
 
+copilot_error_t copilot_client_get_foreground_session_id(
+    copilot_client_t *client,
+    char **out)
+{
+    if (!client || !out) return COPILOT_ERROR_INVALID_ARGUMENT;
+    if (!client->rpc) return COPILOT_ERROR_NOT_CONNECTED;
+
+    cJSON *params = cJSON_CreateObject();
+    int err_code = 0;
+    char *err_msg = NULL;
+    cJSON *result = json_rpc_client_request(client->rpc, "session.getForeground", params, 10000,
+                                            &err_code, &err_msg);
+    cJSON_Delete(params);
+
+    if (!result) {
+        free(err_msg);
+        return COPILOT_ERROR_RPC;
+    }
+
+    cJSON *sid = cJSON_GetObjectItem(result, "sessionId");
+    *out = (sid && cJSON_IsString(sid)) ? strdup(sid->valuestring) : NULL;
+    cJSON_Delete(result);
+
+    return COPILOT_OK;
+}
+
+copilot_error_t copilot_client_set_foreground_session_id(
+    copilot_client_t *client,
+    const char *session_id)
+{
+    if (!client || !session_id) return COPILOT_ERROR_INVALID_ARGUMENT;
+    if (!client->rpc) return COPILOT_ERROR_NOT_CONNECTED;
+
+    cJSON *params = cJSON_CreateObject();
+    cJSON_AddStringToObject(params, "sessionId", session_id);
+
+    int err_code = 0;
+    char *err_msg = NULL;
+    cJSON *result = json_rpc_client_request(client->rpc, "session.setForeground", params, 10000,
+                                            &err_code, &err_msg);
+    cJSON_Delete(params);
+
+    if (!result) {
+        free(err_msg);
+        return COPILOT_ERROR_RPC;
+    }
+
+    cJSON *success = cJSON_GetObjectItem(result, "success");
+    bool ok = success && cJSON_IsTrue(success);
+    cJSON_Delete(result);
+
+    if (!ok) return COPILOT_ERROR_RPC;
+
+    return COPILOT_OK;
+}
+
 /* ============================================================================
  * Public API: Session creation
  * ============================================================================ */

--- a/cobol/src/COPILOT-CLIENT.cob
+++ b/cobol/src/COPILOT-CLIENT.cob
@@ -55,6 +55,7 @@
        01  WS-IO-RETURN-CODE        PIC S9(4)   VALUE 0.
        01  WS-JSON-WORK             PIC X(8192) VALUE SPACES.
        01  WS-JSON-WORK-LEN         PIC 9(5)    VALUE 0.
+       01  WS-FG-SESSION-ID         PIC X(256)  VALUE SPACES.
 
        LINKAGE SECTION.
        01  LS-REQUEST               PIC X(8192).
@@ -110,6 +111,27 @@
       *----------------------------------------------------------------*
        ENTRY "COPILOT-CLIENT-PING" USING WS-RETURN-CODE.
            PERFORM PING-CLI
+           GOBACK
+           .
+
+      *----------------------------------------------------------------*
+      * GET-FG-SESSION: Get the foreground session ID.                 *
+      * Output: WS-FG-SESSION-ID, WS-RETURN-CODE                     *
+      *----------------------------------------------------------------*
+       ENTRY "COPILOT-GET-FG-SESSION" USING WS-FG-SESSION-ID
+           WS-RETURN-CODE.
+           PERFORM GET-FOREGROUND-SESSION
+           GOBACK
+           .
+
+      *----------------------------------------------------------------*
+      * SET-FG-SESSION: Set the foreground session ID.                 *
+      * Input:  WS-FG-SESSION-ID                                      *
+      * Output: WS-RETURN-CODE                                        *
+      *----------------------------------------------------------------*
+       ENTRY "COPILOT-SET-FG-SESSION" USING WS-FG-SESSION-ID
+           WS-RETURN-CODE.
+           PERFORM SET-FOREGROUND-SESSION
            GOBACK
            .
 
@@ -294,6 +316,76 @@
                MOVE 0 TO LS-RETURN-CODE
            ELSE
                MOVE -1 TO LS-RETURN-CODE
+           END-IF
+           .
+
+      *----------------------------------------------------------------*
+      * GET-FOREGROUND-SESSION: Get the current foreground session.     *
+      *----------------------------------------------------------------*
+       GET-FOREGROUND-SESSION.
+           IF NOT CLIENT-IS-ACTIVE
+               MOVE -4 TO WS-RETURN-CODE
+               EXIT PARAGRAPH
+           END-IF
+
+           MOVE SPACES TO WS-WRITE-BUFFER
+           MOVE 1 TO WS-JSON-WORK-LEN
+           STRING
+               '{"jsonrpc":"2.0",'
+               '"method":"session.getForeground",'
+               '"params":{},'
+               '"id":1}'
+               DELIMITED SIZE
+               INTO WS-WRITE-BUFFER
+               WITH POINTER WS-JSON-WORK-LEN
+           END-STRING
+           SUBTRACT 1 FROM WS-JSON-WORK-LEN
+               GIVING WS-WRITE-LEN
+
+           PERFORM WRITE-FRAMED-MESSAGE
+           PERFORM READ-FRAMED-MESSAGE
+
+           IF WS-IO-RETURN-CODE = 0
+               MOVE WS-READ-BUFFER TO WS-FG-SESSION-ID
+               MOVE 0 TO WS-RETURN-CODE
+           ELSE
+               MOVE -4 TO WS-RETURN-CODE
+           END-IF
+           .
+
+      *----------------------------------------------------------------*
+      * SET-FOREGROUND-SESSION: Set the foreground session.             *
+      *----------------------------------------------------------------*
+       SET-FOREGROUND-SESSION.
+           IF NOT CLIENT-IS-ACTIVE
+               MOVE -4 TO WS-RETURN-CODE
+               EXIT PARAGRAPH
+           END-IF
+
+           MOVE SPACES TO WS-WRITE-BUFFER
+           MOVE 1 TO WS-JSON-WORK-LEN
+           STRING
+               '{"jsonrpc":"2.0",'
+               '"method":"session.setForeground",'
+               '"params":{"sessionId":"'
+               FUNCTION TRIM(WS-FG-SESSION-ID)
+               '"},"id":2}'
+               DELIMITED SIZE
+               INTO WS-WRITE-BUFFER
+               WITH POINTER WS-JSON-WORK-LEN
+           END-STRING
+           SUBTRACT 1 FROM WS-JSON-WORK-LEN
+               GIVING WS-WRITE-LEN
+
+           PERFORM WRITE-FRAMED-MESSAGE
+           PERFORM READ-FRAMED-MESSAGE
+
+           IF WS-IO-RETURN-CODE = 0
+               MOVE 0 TO WS-RETURN-CODE
+           ELSE
+               MOVE -4 TO WS-RETURN-CODE
+               MOVE "Failed to set foreground session"
+                   TO WS-LAST-ERROR
            END-IF
            .
 

--- a/crystal/src/copilot_sdk/client.cr
+++ b/crystal/src/copilot_sdk/client.cr
@@ -198,6 +198,25 @@ module CopilotSDK
       sessions_array.map { |s| SessionMetadata.from_json(s.to_json) }
     end
 
+    # Get the foreground session ID.
+    def get_foreground_session_id : String
+      ensure_connected!
+      result = rpc.send_request("session.getForeground")
+      result["sessionId"]?.try(&.as_s) || raise CopilotError.new("No sessionId in response")
+    end
+
+    # Set the foreground session ID.
+    def set_foreground_session_id(session_id : String) : Nil
+      ensure_connected!
+      params = JSON.parse({"sessionId" => session_id}.to_json)
+      result = rpc.send_request("session.setForeground", params)
+      success = result["success"]?.try(&.as_bool?) || false
+      unless success
+        error_msg = result["error"]?.try(&.as_s?) || "Unknown"
+        raise CopilotError.new("Failed to set foreground session: #{error_msg}")
+      end
+    end
+
     # Returns the session with the given ID, or nil.
     def get_session(session_id : String) : CopilotSession?
       @mutex.synchronize { @sessions[session_id]? }

--- a/dlang/source/copilot/client.d
+++ b/dlang/source/copilot/client.d
@@ -236,6 +236,33 @@ final class CopilotClient
         return _rpc.request("getAuthStatus");
     }
 
+    /// Get the foreground session ID.
+    string getForegroundSessionId() @trusted
+    {
+        enforce(_started, "client not started");
+        auto result = _rpc.request("session.getForeground");
+        auto pSid = "sessionId" in result;
+        enforce(pSid !is null && (*pSid).type == JSONType.string,
+            "No sessionId in response");
+        return (*pSid).str;
+    }
+
+    /// Set the foreground session ID.
+    void setForegroundSessionId(string sessionId) @trusted
+    {
+        enforce(_started, "client not started");
+        auto params = JSONValue(["sessionId": JSONValue(sessionId)]);
+        auto result = _rpc.request("session.setForeground", params);
+        auto pSuccess = "success" in result;
+        if (pSuccess is null || (*pSuccess).type != JSONType.true_)
+        {
+            auto pErr = "error" in result;
+            string errMsg = (pErr !is null && (*pErr).type == JSONType.string)
+                ? (*pErr).str : "Unknown";
+            throw new Exception("Failed to set foreground session: " ~ errMsg);
+        }
+    }
+
     // ------------------------------------------------------------------
     // Internal startup helpers
     // ------------------------------------------------------------------

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1599,6 +1599,15 @@ copilot --headless --port 4321
 
 If you don't specify a port, the CLI will choose a random available port.
 
+By default the headless server only accepts connections from loopback (`127.0.0.1`), so the SDK must run on the same machine. To accept connections from other hosts (for example when running the CLI in a container or on a separate server), bind to a non-loopback address with `--host`:
+
+```bash
+# Listen on all interfaces
+copilot --headless --host 0.0.0.0 --port 4321
+```
+
+> **Warning:** Exposing the headless server on a non-loopback address makes it reachable by anyone who can route to that address. Pair it with network controls (firewall, private network, reverse proxy) and authentication appropriate for your environment.
+
 ### Connecting the SDK to the External Server
 
 Once the CLI is running in server mode, configure your SDK client to connect to it using the "cli url" option:

--- a/docs/setup/backend-services.md
+++ b/docs/setup/backend-services.md
@@ -67,15 +67,21 @@ copilot --headless
 # Output: Listening on http://localhost:52431
 ```
 
+By default the headless server only accepts connections from loopback (`127.0.0.1`). To accept connections from other hosts — for example from another machine on your network — bind to a non-loopback address with `--host`:
+
+```bash
+copilot --headless --host 0.0.0.0 --port 4321
+```
+
 For production, run it as a system service or in a container:
 
 ```bash
-# Docker
+# Docker — must bind to 0.0.0.0 so the container's published port is reachable
 docker run -d --name copilot-cli \
     -p 4321:4321 \
     -e COPILOT_GITHUB_TOKEN="$TOKEN" \
     ghcr.io/github/copilot-cli:latest \
-    --headless --port 4321
+    --headless --host 0.0.0.0 --port 4321
 
 # systemd
 [Service]
@@ -415,7 +421,7 @@ version: "3.8"
 services:
   copilot-cli:
     image: ghcr.io/github/copilot-cli:latest
-    command: ["--headless", "--port", "4321"]
+    command: ["--headless", "--host", "0.0.0.0", "--port", "4321"]
     environment:
       - COPILOT_GITHUB_TOKEN=${COPILOT_GITHUB_TOKEN}
     ports:

--- a/docs/setup/scaling.md
+++ b/docs/setup/scaling.md
@@ -520,7 +520,7 @@ spec:
       containers:
         - name: copilot-cli
           image: ghcr.io/github/copilot-cli:latest
-          args: ["--headless", "--port", "4321"]
+          args: ["--headless", "--host", "0.0.0.0", "--port", "4321"]
           env:
             - name: COPILOT_GITHUB_TOKEN
               valueFrom:
@@ -577,7 +577,7 @@ flowchart TB
 containers:
   - name: copilot-cli
     image: ghcr.io/github/copilot-cli:latest
-    command: ["copilot", "--headless", "--port", "4321"]
+    command: ["copilot", "--headless", "--host", "0.0.0.0", "--port", "4321"]
     volumeMounts:
       - name: session-storage
         mountPath: /root/.copilot/session-state

--- a/dotnet/.gitignore
+++ b/dotnet/.gitignore
@@ -16,7 +16,6 @@ src/build/GitHub.Copilot.SDK.props
 *.sln.docstates
 
 # IDE
-.vs/
 .vscode/
 *.swp
 *~

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -10,7 +10,6 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.102" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.24.84" />
     <PackageVersion Include="System.Text.Json" Version="10.0.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -5,8 +5,6 @@
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using StreamJsonRpc;
-using StreamJsonRpc.Protocol;
 using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
@@ -80,7 +78,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private readonly List<Action<SessionLifecycleEvent>> _lifecycleHandlers = [];
     private readonly Dictionary<string, List<Action<SessionLifecycleEvent>>> _typedLifecycleHandlers = [];
     private readonly object _lifecycleHandlersLock = new();
-    private ServerRpc? _rpc;
+    private ServerRpc? _serverRpc;
 
     /// <summary>
     /// Gets the typed RPC client for server-scoped methods (no session required).
@@ -92,7 +90,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     /// <exception cref="InvalidOperationException">Thrown if the client is not started.</exception>
     public ServerRpc Rpc => _disposed
         ? throw new ObjectDisposedException(nameof(CopilotClient))
-        : _rpc ?? throw new InvalidOperationException("Client is not started. Call StartAsync first.");
+        : _serverRpc ?? throw new InvalidOperationException("Client is not started. Call StartAsync first.");
 
     /// <summary>
     /// Gets the actual TCP port the CLI server is listening on, if using TCP transport.
@@ -341,18 +339,12 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         catch (Exception ex) { errors?.Add(ex); }
 
         // Clear RPC and models cache
-        _rpc = null;
+        _serverRpc = null;
         _modelsCache = null;
 
         if (ctx.NetworkStream is not null)
         {
             try { await ctx.NetworkStream.DisposeAsync(); }
-            catch (Exception ex) { errors?.Add(ex); }
-        }
-
-        if (ctx.TcpClient is not null)
-        {
-            try { ctx.TcpClient.Dispose(); }
             catch (Exception ex) { errors?.Add(ex); }
         }
 
@@ -1059,9 +1051,9 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     {
         try
         {
-            return await rpc.InvokeWithCancellationAsync<T>(method, args, cancellationToken);
+            return await rpc.InvokeAsync<T>(method, args, cancellationToken);
         }
-        catch (StreamJsonRpc.ConnectionLostException ex)
+        catch (ConnectionLostException ex)
         {
             string? stderrOutput = null;
             if (stderrBuffer is not null)
@@ -1078,7 +1070,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             }
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
-        catch (StreamJsonRpc.RemoteRpcException ex)
+        catch (RemoteRpcException ex)
         {
             throw new IOException($"Communication error with Copilot CLI: {ex.Message}", ex);
         }
@@ -1329,12 +1321,15 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private async Task<Connection> ConnectToServerAsync(Process? cliProcess, string? tcpHost, int? tcpPort, StringBuilder? stderrBuffer, CancellationToken cancellationToken)
     {
         Stream inputStream, outputStream;
-        TcpClient? tcpClient = null;
         NetworkStream? networkStream = null;
 
         if (_options.UseStdio)
         {
-            if (cliProcess == null) throw new InvalidOperationException("CLI process not started");
+            if (cliProcess == null)
+            {
+                throw new InvalidOperationException("CLI process not started");
+            }
+
             inputStream = cliProcess.StandardOutput.BaseStream;
             outputStream = cliProcess.StandardInput.BaseStream;
         }
@@ -1345,33 +1340,38 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 throw new InvalidOperationException("Cannot connect because TCP host or port are not available");
             }
 
-            tcpClient = new();
-            await tcpClient.ConnectAsync(tcpHost, tcpPort.Value, cancellationToken);
-            networkStream = tcpClient.GetStream();
-            inputStream = networkStream;
-            outputStream = networkStream;
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            try
+            {
+                await socket.ConnectAsync(tcpHost, tcpPort.Value, cancellationToken);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+
+            inputStream = outputStream = networkStream = new NetworkStream(socket, ownsSocket: true);
         }
 
-        var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(
+        var rpc = new JsonRpc(
             outputStream,
             inputStream,
-            CreateSystemTextJsonFormatter()))
-        {
-            TraceSource = new LoggerTraceSource(_logger),
-        };
+            SerializerOptionsForMessageFormatter,
+            _logger);
 
         var handler = new RpcHandler(this);
-        rpc.AddLocalRpcMethod("session.event", handler.OnSessionEvent);
-        rpc.AddLocalRpcMethod("session.lifecycle", handler.OnSessionLifecycle);
+        rpc.SetLocalRpcMethod("session.event", handler.OnSessionEvent);
+        rpc.SetLocalRpcMethod("session.lifecycle", handler.OnSessionLifecycle);
         // Protocol v3 servers send tool calls / permission requests as broadcast events.
         // Protocol v2 servers use the older tool.call / permission.request RPC model.
         // We always register v2 adapters because handlers are set up before version
         // negotiation; a v3 server will simply never send these requests.
-        rpc.AddLocalRpcMethod("tool.call", handler.OnToolCallV2);
-        rpc.AddLocalRpcMethod("permission.request", handler.OnPermissionRequestV2);
-        rpc.AddLocalRpcMethod("userInput.request", handler.OnUserInputRequest);
-        rpc.AddLocalRpcMethod("hooks.invoke", handler.OnHooksInvoke);
-        rpc.AddLocalRpcMethod("systemMessage.transform", handler.OnSystemMessageTransform);
+        rpc.SetLocalRpcMethod("tool.call", handler.OnToolCallV2);
+        rpc.SetLocalRpcMethod("permission.request", handler.OnPermissionRequestV2);
+        rpc.SetLocalRpcMethod("userInput.request", handler.OnUserInputRequest);
+        rpc.SetLocalRpcMethod("hooks.invoke", handler.OnHooksInvoke);
+        rpc.SetLocalRpcMethod("systemMessage.transform", handler.OnSystemMessageTransform);
         ClientSessionApiRegistration.RegisterClientSessionApiHandlers(rpc, sessionId =>
         {
             var session = GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
@@ -1380,18 +1380,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         rpc.StartListening();
 
         // Transition state to Disconnected if the JSON-RPC connection drops
-        _ = rpc.Completion.ContinueWith(_ => _disconnected = true, TaskScheduler.Default);
+        _ = rpc.Completion.ContinueWith(_ => _disconnected = true, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
-        _rpc = new ServerRpc(rpc);
+        _serverRpc = new ServerRpc(rpc);
 
-        return new Connection(rpc, cliProcess, tcpClient, networkStream, stderrBuffer);
-    }
-
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Using happy path from https://microsoft.github.io/vs-streamjsonrpc/docs/nativeAOT.html")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Using happy path from https://microsoft.github.io/vs-streamjsonrpc/docs/nativeAOT.html")]
-    private static SystemTextJsonFormatter CreateSystemTextJsonFormatter()
-    {
-        return new() { JsonSerializerOptions = SerializerOptionsForMessageFormatter };
+        return new Connection(rpc, cliProcess, networkStream, stderrBuffer);
     }
 
     private static JsonSerializerOptions SerializerOptionsForMessageFormatter { get; } = CreateSerializerOptions();
@@ -1409,12 +1402,6 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         options.TypeInfoResolverChain.Add(CopilotSession.SessionJsonContext.Default);
         options.TypeInfoResolverChain.Add(SessionEventsJsonContext.Default);
         options.TypeInfoResolverChain.Add(SDK.Rpc.RpcJsonContext.Default);
-
-        // StreamJsonRpc's RequestId needs serialization when CancellationToken fires during
-        // JSON-RPC operations. Its built-in converter (RequestIdSTJsonConverter) is internal,
-        // and [JsonSerializable] can't source-gen for it (SYSLIB1220), so we provide our own
-        // AOT-safe resolver + converter.
-        options.TypeInfoResolverChain.Add(new RequestIdTypeInfoResolver());
 
         options.MakeReadOnly();
 
@@ -1484,7 +1471,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             client.DispatchLifecycleEvent(evt);
         }
 
-        public async Task<UserInputRequestResponse> OnUserInputRequest(string sessionId, string question, IList<string>? choices = null, bool? allowFreeform = null)
+        public async ValueTask<UserInputRequestResponse> OnUserInputRequest(string sessionId, string question, IList<string>? choices = null, bool? allowFreeform = null)
         {
             var session = client.GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
             var request = new UserInputRequest
@@ -1498,14 +1485,14 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             return new UserInputRequestResponse(result.Answer, result.WasFreeform);
         }
 
-        public async Task<HooksInvokeResponse> OnHooksInvoke(string sessionId, string hookType, JsonElement input)
+        public async ValueTask<HooksInvokeResponse> OnHooksInvoke(string sessionId, string hookType, JsonElement input)
         {
             var session = client.GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
             var output = await session.HandleHooksInvokeAsync(hookType, input);
             return new HooksInvokeResponse(output);
         }
 
-        public async Task<SystemMessageTransformRpcResponse> OnSystemMessageTransform(string sessionId, JsonElement sections)
+        public async ValueTask<SystemMessageTransformRpcResponse> OnSystemMessageTransform(string sessionId, JsonElement sections)
         {
             var session = client.GetSession(sessionId) ?? throw new ArgumentException($"Unknown session {sessionId}");
             return await session.HandleSystemMessageTransformAsync(sections);
@@ -1513,7 +1500,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
 
         // Protocol v2 backward-compatibility adapters
 
-        public async Task<ToolCallResponseV2> OnToolCallV2(string sessionId,
+        public async ValueTask<ToolCallResponseV2> OnToolCallV2(string sessionId,
             string toolCallId,
             string toolName,
             object? arguments,
@@ -1580,7 +1567,7 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
             }
         }
 
-        public async Task<PermissionRequestResponseV2> OnPermissionRequestV2(string sessionId, JsonElement permissionRequest)
+        public async ValueTask<PermissionRequestResponseV2> OnPermissionRequestV2(string sessionId, JsonElement permissionRequest)
         {
             var session = client.GetSession(sessionId)
                 ?? throw new ArgumentException($"Unknown session {sessionId}");
@@ -1611,12 +1598,10 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     private class Connection(
         JsonRpc rpc,
         Process? cliProcess, // Set if we created the child process
-        TcpClient? tcpClient, // Set if using TCP
         NetworkStream? networkStream, // Set if using TCP
         StringBuilder? stderrBuffer = null) // Captures stderr for error messages
     {
         public Process? CliProcess => cliProcess;
-        public TcpClient? TcpClient => tcpClient;
         public JsonRpc Rpc => rpc;
         public NetworkStream? NetworkStream => networkStream;
         public StringBuilder? StderrBuffer => stderrBuffer;
@@ -1770,90 +1755,11 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     internal record PermissionRequestResponseV2(
         PermissionRequestResult Result);
 
-    /// <summary>Trace source that forwards all logs to the ILogger.</summary>
-    internal sealed class LoggerTraceSource : TraceSource
-    {
-        public LoggerTraceSource(ILogger logger) : base(nameof(LoggerTraceSource), SourceLevels.All)
-        {
-            Listeners.Clear();
-            Listeners.Add(new LoggerTraceListener(logger));
-        }
-
-        private sealed class LoggerTraceListener(ILogger logger) : TraceListener
-        {
-            public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message)
-            {
-                LogLevel level = MapLevel(eventType);
-                if (logger.IsEnabled(level))
-                {
-                    logger.Log(level, "[{Source}] {Message}", source, message);
-                }
-            }
-
-            public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? format, params object?[]? args)
-            {
-                LogLevel level = MapLevel(eventType);
-                if (logger.IsEnabled(level))
-                {
-                    logger.Log(level, "[{Source}] {Message}", source, args is null || args.Length == 0 ? format : string.Format(CultureInfo.InvariantCulture, format ?? "", args));
-                }
-            }
-
-            public override void TraceData(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, object? data)
-            {
-                LogLevel level = MapLevel(eventType);
-                if (logger.IsEnabled(level))
-                {
-                    logger.Log(level, "[{Source}] {Data}", source, data);
-                }
-            }
-
-            public override void TraceData(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, params object?[]? data)
-            {
-                LogLevel level = MapLevel(eventType);
-                if (logger.IsEnabled(level))
-                {
-                    logger.Log(level, "[{Source}] {Data}", source, data is null ? null : string.Join(", ", data));
-                }
-            }
-
-            public override void Write(string? message)
-            {
-                if (logger.IsEnabled(LogLevel.Trace))
-                {
-                    logger.LogTrace("{Message}", message);
-                }
-            }
-
-            public override void WriteLine(string? message)
-            {
-                if (logger.IsEnabled(LogLevel.Trace))
-                {
-                    logger.LogTrace("{Message}", message);
-                }
-            }
-
-            private static LogLevel MapLevel(TraceEventType eventType)
-            {
-                return eventType switch
-                {
-                    TraceEventType.Critical => LogLevel.Critical,
-                    TraceEventType.Error => LogLevel.Error,
-                    TraceEventType.Warning => LogLevel.Warning,
-                    TraceEventType.Information => LogLevel.Information,
-                    TraceEventType.Verbose => LogLevel.Debug,
-                    _ => LogLevel.Trace
-                };
-            }
-        }
-    }
-
     [JsonSourceGenerationOptions(
         JsonSerializerDefaults.Web,
         AllowOutOfOrderMetadataProperties = true,
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonSerializable(typeof(CommonErrorData))]
     [JsonSerializable(typeof(CreateSessionRequest))]
     [JsonSerializable(typeof(CreateSessionResponse))]
     [JsonSerializable(typeof(CustomAgentConfig))]
@@ -1886,50 +1792,6 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
     [JsonSerializable(typeof(UserInputRequest))]
     [JsonSerializable(typeof(UserInputResponse))]
     internal partial class ClientJsonContext : JsonSerializerContext;
-
-    /// <summary>
-    /// AOT-safe type info resolver for <see cref="RequestId"/>.
-    /// StreamJsonRpc's own RequestIdSTJsonConverter is internal (SYSLIB1220/CS0122),
-    /// so we provide our own converter and wire it through <see cref="JsonMetadataServices.CreateValueInfo{T}"/>
-    /// to stay fully AOT/trimming-compatible.
-    /// </summary>
-    private sealed class RequestIdTypeInfoResolver : IJsonTypeInfoResolver
-    {
-        public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options)
-        {
-            if (type == typeof(RequestId))
-                return JsonMetadataServices.CreateValueInfo<RequestId>(options, new RequestIdJsonConverter());
-            return null;
-        }
-    }
-
-    private sealed class RequestIdJsonConverter : JsonConverter<RequestId>
-    {
-        public override RequestId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            return reader.TokenType switch
-            {
-                JsonTokenType.Number => reader.TryGetInt64(out long val)
-                    ? new RequestId(val)
-                    : new RequestId(reader.HasValueSequence
-                        ? Encoding.UTF8.GetString(reader.ValueSequence)
-                        : Encoding.UTF8.GetString(reader.ValueSpan)),
-                JsonTokenType.String => new RequestId(reader.GetString()!),
-                JsonTokenType.Null => RequestId.Null,
-                _ => throw new JsonException($"Unexpected token type for RequestId: {reader.TokenType}"),
-            };
-        }
-
-        public override void Write(Utf8JsonWriter writer, RequestId value, JsonSerializerOptions options)
-        {
-            if (value.Number.HasValue)
-                writer.WriteNumberValue(value.Number.Value);
-            else if (value.String is not null)
-                writer.WriteStringValue(value.String);
-            else
-                writer.WriteNullValue();
-        }
-    }
 
     [GeneratedRegex(@"listening on port ([0-9]+)", RegexOptions.IgnoreCase)]
     private static partial Regex ListeningOnPortRegex();

--- a/dotnet/src/Client.cs
+++ b/dotnet/src/Client.cs
@@ -632,7 +632,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
                 Traceparent: traceparent,
                 Tracestate: tracestate,
                 ModelCapabilities: config.ModelCapabilities,
-                GitHubToken: config.GitHubToken);
+                GitHubToken: config.GitHubToken,
+                ContinuePendingWork: config.ContinuePendingWork);
 
             var response = await InvokeRpcAsync<ResumeSessionResponse>(
                 connection.Rpc, "session.resume", [request], cancellationToken);
@@ -1705,7 +1706,8 @@ public sealed partial class CopilotClient : IDisposable, IAsyncDisposable
         string? Traceparent = null,
         string? Tracestate = null,
         ModelCapabilitiesOverride? ModelCapabilities = null,
-        string? GitHubToken = null);
+        string? GitHubToken = null,
+        bool? ContinuePendingWork = null);
 
     internal record ResumeSessionResponse(
         string SessionId,

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -12,7 +12,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;
 
@@ -4096,7 +4095,7 @@ public sealed class ClientSessionApiHandlers
 }
 
 /// <summary>Registers client session API handlers on a JSON-RPC connection.</summary>
-public static class ClientSessionApiRegistration
+internal static class ClientSessionApiRegistration
 {
     /// <summary>
     /// Registers handlers for server-to-client session API calls.
@@ -4105,106 +4104,66 @@ public static class ClientSessionApiRegistration
     /// </summary>
     public static void RegisterClientSessionApiHandlers(JsonRpc rpc, Func<string, ClientSessionApiHandlers> getHandlers)
     {
-        var registerSessionFsReadFileMethod = (Func<SessionFsReadFileRequest, CancellationToken, Task<SessionFsReadFileResult>>)(async (request, cancellationToken) =>
+        rpc.SetLocalRpcMethod("sessionFs.readFile", (Func<SessionFsReadFileRequest, CancellationToken, ValueTask<SessionFsReadFileResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.ReadFileAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsReadFileMethod.Method, registerSessionFsReadFileMethod.Target!, new JsonRpcMethodAttribute("sessionFs.readFile")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsWriteFileMethod = (Func<SessionFsWriteFileRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.writeFile", (Func<SessionFsWriteFileRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.WriteFileAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsWriteFileMethod.Method, registerSessionFsWriteFileMethod.Target!, new JsonRpcMethodAttribute("sessionFs.writeFile")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsAppendFileMethod = (Func<SessionFsAppendFileRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.appendFile", (Func<SessionFsAppendFileRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.AppendFileAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsAppendFileMethod.Method, registerSessionFsAppendFileMethod.Target!, new JsonRpcMethodAttribute("sessionFs.appendFile")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsExistsMethod = (Func<SessionFsExistsRequest, CancellationToken, Task<SessionFsExistsResult>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.exists", (Func<SessionFsExistsRequest, CancellationToken, ValueTask<SessionFsExistsResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.ExistsAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsExistsMethod.Method, registerSessionFsExistsMethod.Target!, new JsonRpcMethodAttribute("sessionFs.exists")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsStatMethod = (Func<SessionFsStatRequest, CancellationToken, Task<SessionFsStatResult>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.stat", (Func<SessionFsStatRequest, CancellationToken, ValueTask<SessionFsStatResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.StatAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsStatMethod.Method, registerSessionFsStatMethod.Target!, new JsonRpcMethodAttribute("sessionFs.stat")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsMkdirMethod = (Func<SessionFsMkdirRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.mkdir", (Func<SessionFsMkdirRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.MkdirAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsMkdirMethod.Method, registerSessionFsMkdirMethod.Target!, new JsonRpcMethodAttribute("sessionFs.mkdir")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsReaddirMethod = (Func<SessionFsReaddirRequest, CancellationToken, Task<SessionFsReaddirResult>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.readdir", (Func<SessionFsReaddirRequest, CancellationToken, ValueTask<SessionFsReaddirResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.ReaddirAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsReaddirMethod.Method, registerSessionFsReaddirMethod.Target!, new JsonRpcMethodAttribute("sessionFs.readdir")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsReaddirWithTypesMethod = (Func<SessionFsReaddirWithTypesRequest, CancellationToken, Task<SessionFsReaddirWithTypesResult>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.readdirWithTypes", (Func<SessionFsReaddirWithTypesRequest, CancellationToken, ValueTask<SessionFsReaddirWithTypesResult>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.ReaddirWithTypesAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsReaddirWithTypesMethod.Method, registerSessionFsReaddirWithTypesMethod.Target!, new JsonRpcMethodAttribute("sessionFs.readdirWithTypes")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsRmMethod = (Func<SessionFsRmRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.rm", (Func<SessionFsRmRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.RmAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsRmMethod.Method, registerSessionFsRmMethod.Target!, new JsonRpcMethodAttribute("sessionFs.rm")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
-        var registerSessionFsRenameMethod = (Func<SessionFsRenameRequest, CancellationToken, Task<SessionFsError?>>)(async (request, cancellationToken) =>
+        }), singleObjectParam: true);
+        rpc.SetLocalRpcMethod("sessionFs.rename", (Func<SessionFsRenameRequest, CancellationToken, ValueTask<SessionFsError?>>)(async (request, cancellationToken) =>
         {
             var handler = getHandlers(request.SessionId).SessionFs;
             if (handler is null) throw new InvalidOperationException($"No sessionFs handler registered for session: {request.SessionId}");
             return await handler.RenameAsync(request, cancellationToken);
-        });
-        rpc.AddLocalRpcMethod(registerSessionFsRenameMethod.Method, registerSessionFsRenameMethod.Target!, new JsonRpcMethodAttribute("sessionFs.rename")
-        {
-            UseSingleObjectParameterDeserialization = true
-        });
+        }), singleObjectParam: true);
     }
 }
 

--- a/dotnet/src/Generated/Rpc.cs
+++ b/dotnet/src/Generated/Rpc.cs
@@ -1676,16 +1676,16 @@ internal sealed class SessionExtensionsReloadRequest
     public string SessionId { get; set; } = string.Empty;
 }
 
-/// <summary>RPC data type for HandleToolCall operations.</summary>
-public sealed class HandleToolCallResult
+/// <summary>RPC data type for HandlePendingToolCall operations.</summary>
+public sealed class HandlePendingToolCallResult
 {
     /// <summary>Whether the tool call result was handled successfully.</summary>
     [JsonPropertyName("success")]
     public bool Success { get; set; }
 }
 
-/// <summary>RPC data type for ToolsHandlePendingToolCall operations.</summary>
-internal sealed class ToolsHandlePendingToolCallRequest
+/// <summary>RPC data type for HandlePendingToolCall operations.</summary>
+internal sealed class HandlePendingToolCallRequest
 {
     /// <summary>Error message if the tool call failed.</summary>
     [JsonPropertyName("error")]
@@ -1811,6 +1811,7 @@ public sealed class PermissionRequestResult
 [JsonDerivedType(typeof(PermissionDecisionApproveOnce), "approve-once")]
 [JsonDerivedType(typeof(PermissionDecisionApproveForSession), "approve-for-session")]
 [JsonDerivedType(typeof(PermissionDecisionApproveForLocation), "approve-for-location")]
+[JsonDerivedType(typeof(PermissionDecisionApprovePermanently), "approve-permanently")]
 [JsonDerivedType(typeof(PermissionDecisionReject), "reject")]
 [JsonDerivedType(typeof(PermissionDecisionUserNotAvailable), "user-not-available")]
 public partial class PermissionDecision
@@ -1933,8 +1934,14 @@ public partial class PermissionDecisionApproveForSession : PermissionDecision
     public override string Kind => "approve-for-session";
 
     /// <summary>The approval to add as a session-scoped rule.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("approval")]
-    public required PermissionDecisionApproveForSessionApproval Approval { get; set; }
+    public PermissionDecisionApproveForSessionApproval? Approval { get; set; }
+
+    /// <summary>The URL domain to approve for this session.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("domain")]
+    public string? Domain { get; set; }
 }
 
 /// <summary>The approval to persist for this location.</summary>
@@ -2047,6 +2054,18 @@ public partial class PermissionDecisionApproveForLocation : PermissionDecision
     /// <summary>The location key (git root or cwd) to persist the approval to.</summary>
     [JsonPropertyName("locationKey")]
     public required string LocationKey { get; set; }
+}
+
+/// <summary>The <c>approve-permanently</c> variant of <see cref="PermissionDecision"/>.</summary>
+public partial class PermissionDecisionApprovePermanently : PermissionDecision
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "approve-permanently";
+
+    /// <summary>The URL domain to approve permanently.</summary>
+    [JsonPropertyName("domain")]
+    public required string Domain { get; set; }
 }
 
 /// <summary>The <c>reject</c> variant of <see cref="PermissionDecision"/>.</summary>
@@ -2293,6 +2312,15 @@ public sealed class UsageMetricsModelMetricRequests
     public long Count { get; set; }
 }
 
+/// <summary>RPC data type for UsageMetricsModelMetricTokenDetail operations.</summary>
+public sealed class UsageMetricsModelMetricTokenDetail
+{
+    /// <summary>Accumulated token count for this token type.</summary>
+    [Range((double)0, (double)long.MaxValue)]
+    [JsonPropertyName("tokenCount")]
+    public long TokenCount { get; set; }
+}
+
 /// <summary>Token usage metrics for this model.</summary>
 public sealed class UsageMetricsModelMetricUsage
 {
@@ -2329,9 +2357,27 @@ public sealed class UsageMetricsModelMetric
     [JsonPropertyName("requests")]
     public UsageMetricsModelMetricRequests Requests { get => field ??= new(); set; }
 
+    /// <summary>Token count details per type.</summary>
+    [JsonPropertyName("tokenDetails")]
+    public IDictionary<string, UsageMetricsModelMetricTokenDetail>? TokenDetails { get; set; }
+
+    /// <summary>Accumulated nano-AI units cost for this model.</summary>
+    [Range((double)0, (double)long.MaxValue)]
+    [JsonPropertyName("totalNanoAiu")]
+    public long? TotalNanoAiu { get; set; }
+
     /// <summary>Token usage metrics for this model.</summary>
     [JsonPropertyName("usage")]
     public UsageMetricsModelMetricUsage Usage { get => field ??= new(); set; }
+}
+
+/// <summary>RPC data type for UsageMetricsTokenDetail operations.</summary>
+public sealed class UsageMetricsTokenDetail
+{
+    /// <summary>Accumulated token count for this token type.</summary>
+    [Range((double)0, (double)long.MaxValue)]
+    [JsonPropertyName("tokenCount")]
+    public long TokenCount { get; set; }
 }
 
 /// <summary>RPC data type for UsageGetMetrics operations.</summary>
@@ -2364,11 +2410,20 @@ public sealed class UsageGetMetricsResult
     [JsonPropertyName("sessionStartTime")]
     public long SessionStartTime { get; set; }
 
+    /// <summary>Session-wide per-token-type accumulated token counts.</summary>
+    [JsonPropertyName("tokenDetails")]
+    public IDictionary<string, UsageMetricsTokenDetail>? TokenDetails { get; set; }
+
     /// <summary>Total time spent in model API calls (milliseconds).</summary>
     [Range(0, double.MaxValue)]
     [JsonConverter(typeof(MillisecondsTimeSpanConverter))]
     [JsonPropertyName("totalApiDurationMs")]
     public TimeSpan TotalApiDurationMs { get; set; }
+
+    /// <summary>Session-wide accumulated nano-AI units cost.</summary>
+    [Range((double)0, (double)long.MaxValue)]
+    [JsonPropertyName("totalNanoAiu")]
+    public long? TotalNanoAiu { get; set; }
 
     /// <summary>Total user-initiated premium request cost across all models (may be fractional due to multipliers).</summary>
     [JsonPropertyName("totalPremiumRequestCost")]
@@ -3898,10 +3953,10 @@ public sealed class ToolsApi
     }
 
     /// <summary>Calls "session.tools.handlePendingToolCall".</summary>
-    public async Task<HandleToolCallResult> HandlePendingToolCallAsync(string requestId, object? result = null, string? error = null, CancellationToken cancellationToken = default)
+    public async Task<HandlePendingToolCallResult> HandlePendingToolCallAsync(string requestId, object? result = null, string? error = null, CancellationToken cancellationToken = default)
     {
-        var request = new ToolsHandlePendingToolCallRequest { SessionId = _sessionId, RequestId = requestId, Result = result, Error = error };
-        return await CopilotClient.InvokeRpcAsync<HandleToolCallResult>(_rpc, "session.tools.handlePendingToolCall", [request], cancellationToken);
+        var request = new HandlePendingToolCallRequest { SessionId = _sessionId, RequestId = requestId, Result = result, Error = error };
+        return await CopilotClient.InvokeRpcAsync<HandlePendingToolCallResult>(_rpc, "session.tools.handlePendingToolCall", [request], cancellationToken);
     }
 }
 
@@ -4190,7 +4245,8 @@ internal static class ClientSessionApiRegistration
 [JsonSerializable(typeof(ExtensionsEnableRequest))]
 [JsonSerializable(typeof(FleetStartRequest))]
 [JsonSerializable(typeof(FleetStartResult))]
-[JsonSerializable(typeof(HandleToolCallResult))]
+[JsonSerializable(typeof(HandlePendingToolCallRequest))]
+[JsonSerializable(typeof(HandlePendingToolCallResult))]
 [JsonSerializable(typeof(HistoryCompactContextWindow))]
 [JsonSerializable(typeof(HistoryCompactResult))]
 [JsonSerializable(typeof(HistoryTruncateRequest))]
@@ -4316,7 +4372,6 @@ internal static class ClientSessionApiRegistration
 [JsonSerializable(typeof(TasksStartAgentResult))]
 [JsonSerializable(typeof(Tool))]
 [JsonSerializable(typeof(ToolList))]
-[JsonSerializable(typeof(ToolsHandlePendingToolCallRequest))]
 [JsonSerializable(typeof(ToolsListRequest))]
 [JsonSerializable(typeof(UIElicitationRequest))]
 [JsonSerializable(typeof(UIElicitationResponse))]
@@ -4327,7 +4382,9 @@ internal static class ClientSessionApiRegistration
 [JsonSerializable(typeof(UsageMetricsCodeChanges))]
 [JsonSerializable(typeof(UsageMetricsModelMetric))]
 [JsonSerializable(typeof(UsageMetricsModelMetricRequests))]
+[JsonSerializable(typeof(UsageMetricsModelMetricTokenDetail))]
 [JsonSerializable(typeof(UsageMetricsModelMetricUsage))]
+[JsonSerializable(typeof(UsageMetricsTokenDetail))]
 [JsonSerializable(typeof(WorkspacesCreateFileRequest))]
 [JsonSerializable(typeof(WorkspacesGetWorkspaceResult))]
 [JsonSerializable(typeof(WorkspacesGetWorkspaceResultWorkspace))]

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -4643,6 +4643,11 @@ public partial class McpOauthRequiredStaticClientConfig
     [JsonPropertyName("clientId")]
     public required string ClientId { get; set; }
 
+    /// <summary>Optional non-default OAuth grant type. When set to 'client_credentials', the OAuth flow runs headlessly using the client_id + keychain-stored secret (no browser, no callback server).</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("grantType")]
+    public string? GrantType { get; set; }
+
     /// <summary>Whether this is a public OAuth client.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("publicClient")]

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -1192,6 +1192,11 @@ public partial class SessionResumeData
     [JsonPropertyName("context")]
     public WorkingDirectoryContext? Context { get; set; }
 
+    /// <summary>When true, tool calls and permission requests left in flight by the previous session lifetime remain pending after resume and the agentic loop awaits their results. User sends are queued behind the pending work until all such requests reach a terminal state. When false (the default), any such tool calls and permission requests are immediately marked as interrupted on resume.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("continuePendingWork")]
+    public bool? ContinuePendingWork { get; set; }
+
     /// <summary>Total number of persisted events in the session at the time of resume.</summary>
     [JsonPropertyName("eventCount")]
     public required double EventCount { get; set; }
@@ -1214,6 +1219,11 @@ public partial class SessionResumeData
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("selectedModel")]
     public string? SelectedModel { get; set; }
+
+    /// <summary>True when this resume attached to a session that the runtime already had running in-memory (for example, an extension joining a session another client was actively driving). False (or omitted) for cold resumes — the runtime had to reconstitute the session from its persisted event log.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("sessionWasActive")]
+    public bool? SessionWasActive { get; set; }
 }
 
 /// <summary>Notifies Mission Control that the session's remote steering capability has changed.</summary>
@@ -1517,6 +1527,11 @@ public partial class SessionShutdownData
     [JsonPropertyName("systemTokens")]
     public double? SystemTokens { get; set; }
 
+    /// <summary>Session-wide per-token-type accumulated token counts.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("tokenDetails")]
+    public IDictionary<string, ShutdownTokenDetail>? TokenDetails { get; set; }
+
     /// <summary>Tool definitions token count at shutdown.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolDefinitionsTokens")]
@@ -1525,6 +1540,11 @@ public partial class SessionShutdownData
     /// <summary>Cumulative time spent in API calls during the session, in milliseconds.</summary>
     [JsonPropertyName("totalApiDurationMs")]
     public required double TotalApiDurationMs { get; set; }
+
+    /// <summary>Session-wide accumulated nano-AI units cost.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("totalNanoAiu")]
+    public double? TotalNanoAiu { get; set; }
 
     /// <summary>Total number of premium API requests used during the session.</summary>
     [JsonPropertyName("totalPremiumRequests")]
@@ -1748,6 +1768,11 @@ public partial class UserMessageData
     [JsonPropertyName("nativeDocumentPathFallbackPaths")]
     public string[]? NativeDocumentPathFallbackPaths { get; set; }
 
+    /// <summary>Parent agent task ID for background telemetry correlated to this user turn.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("parentAgentTaskId")]
+    public string? ParentAgentTaskId { get; set; }
+
     /// <summary>Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user).</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("source")]
@@ -1878,6 +1903,11 @@ public partial class AssistantMessageData
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolRequests")]
     public AssistantMessageToolRequest[]? ToolRequests { get; set; }
+
+    /// <summary>Identifier for the agent loop turn that produced this message, matching the corresponding assistant.turn_start event.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("turnId")]
+    public string? TurnId { get; set; }
 }
 
 /// <summary>Streaming assistant message delta for incremental response updates.</summary>
@@ -2094,6 +2124,11 @@ public partial class ToolExecutionStartData
     /// <summary>Name of the tool being executed.</summary>
     [JsonPropertyName("toolName")]
     public required string ToolName { get; set; }
+
+    /// <summary>Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("turnId")]
+    public string? TurnId { get; set; }
 }
 
 /// <summary>Streaming tool execution output for incremental result display.</summary>
@@ -2166,6 +2201,11 @@ public partial class ToolExecutionCompleteData
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("toolTelemetry")]
     public IDictionary<string, object>? ToolTelemetry { get; set; }
+
+    /// <summary>Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("turnId")]
+    public string? TurnId { get; set; }
 }
 
 /// <summary>Skill invocation details including content, allowed tools, and plugin metadata.</summary>
@@ -2429,7 +2469,7 @@ public partial class PermissionCompletedData
 
     /// <summary>The result of the permission request.</summary>
     [JsonPropertyName("result")]
-    public required PermissionCompletedResult Result { get; set; }
+    public required PermissionResult Result { get; set; }
 
     /// <summary>Optional tool call ID associated with this permission prompt; clients may use it to correlate UI created from tool-scoped prompts.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -2929,6 +2969,14 @@ public partial class ShutdownModelMetricRequests
     public required double Count { get; set; }
 }
 
+/// <summary>Nested data type for <c>ShutdownModelMetricTokenDetail</c>.</summary>
+public partial class ShutdownModelMetricTokenDetail
+{
+    /// <summary>Accumulated token count for this token type.</summary>
+    [JsonPropertyName("tokenCount")]
+    public required double TokenCount { get; set; }
+}
+
 /// <summary>Token usage breakdown.</summary>
 /// <remarks>Nested data type for <c>ShutdownModelMetricUsage</c>.</remarks>
 public partial class ShutdownModelMetricUsage
@@ -2962,9 +3010,27 @@ public partial class ShutdownModelMetric
     [JsonPropertyName("requests")]
     public required ShutdownModelMetricRequests Requests { get; set; }
 
+    /// <summary>Token count details per type.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("tokenDetails")]
+    public IDictionary<string, ShutdownModelMetricTokenDetail>? TokenDetails { get; set; }
+
+    /// <summary>Accumulated nano-AI units cost for this model.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("totalNanoAiu")]
+    public double? TotalNanoAiu { get; set; }
+
     /// <summary>Token usage breakdown.</summary>
     [JsonPropertyName("usage")]
     public required ShutdownModelMetricUsage Usage { get; set; }
+}
+
+/// <summary>Nested data type for <c>ShutdownTokenDetail</c>.</summary>
+public partial class ShutdownTokenDetail
+{
+    /// <summary>Accumulated token count for this token type.</summary>
+    [JsonPropertyName("tokenCount")]
+    public required double TokenCount { get; set; }
 }
 
 /// <summary>Token usage detail for a single billing category.</summary>
@@ -2996,7 +3062,7 @@ public partial class CompactionCompleteCompactionTokensUsedCopilotUsage
     [JsonPropertyName("tokenDetails")]
     public required CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail[] TokenDetails { get; set; }
 
-    /// <summary>Total cost in nano-AIU (AI Units) for this request.</summary>
+    /// <summary>Total cost in nano-AI units for this request.</summary>
     [JsonPropertyName("totalNanoAiu")]
     public required double TotalNanoAiu { get; set; }
 }
@@ -3294,7 +3360,7 @@ public partial class AssistantUsageCopilotUsage
     [JsonPropertyName("tokenDetails")]
     public required AssistantUsageCopilotUsageTokenDetail[] TokenDetails { get; set; }
 
-    /// <summary>Total cost in nano-AIU (AI Units) for this request.</summary>
+    /// <summary>Total cost in nano-AI units for this request.</summary>
     [JsonPropertyName("totalNanoAiu")]
     public required double TotalNanoAiu { get; set; }
 }
@@ -4313,14 +4379,243 @@ public partial class PermissionPromptRequest
 }
 
 
-/// <summary>The result of the permission request.</summary>
-/// <remarks>Nested data type for <c>PermissionCompletedResult</c>.</remarks>
-public partial class PermissionCompletedResult
+/// <summary>The <c>approved</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultApproved : PermissionResult
 {
-    /// <summary>The outcome of the permission request.</summary>
-    [JsonPropertyName("kind")]
-    public required PermissionCompletedKind Kind { get; set; }
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "approved";
 }
+
+/// <summary>The <c>commands</c> variant of <see cref="UserToolSessionApproval"/>.</summary>
+public partial class UserToolSessionApprovalCommands : UserToolSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "commands";
+
+    /// <summary>Command identifiers approved by the user.</summary>
+    [JsonPropertyName("commandIdentifiers")]
+    public required string[] CommandIdentifiers { get; set; }
+}
+
+/// <summary>The <c>read</c> variant of <see cref="UserToolSessionApproval"/>.</summary>
+public partial class UserToolSessionApprovalRead : UserToolSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "read";
+}
+
+/// <summary>The <c>write</c> variant of <see cref="UserToolSessionApproval"/>.</summary>
+public partial class UserToolSessionApprovalWrite : UserToolSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "write";
+}
+
+/// <summary>The <c>mcp</c> variant of <see cref="UserToolSessionApproval"/>.</summary>
+public partial class UserToolSessionApprovalMcp : UserToolSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "mcp";
+
+    /// <summary>MCP server name.</summary>
+    [JsonPropertyName("serverName")]
+    public required string ServerName { get; set; }
+
+    /// <summary>Optional MCP tool name, or null for all tools on the server.</summary>
+    [JsonPropertyName("toolName")]
+    public string? ToolName { get; set; }
+}
+
+/// <summary>The <c>memory</c> variant of <see cref="UserToolSessionApproval"/>.</summary>
+public partial class UserToolSessionApprovalMemory : UserToolSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "memory";
+}
+
+/// <summary>The <c>custom-tool</c> variant of <see cref="UserToolSessionApproval"/>.</summary>
+public partial class UserToolSessionApprovalCustomTool : UserToolSessionApproval
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "custom-tool";
+
+    /// <summary>Custom tool name.</summary>
+    [JsonPropertyName("toolName")]
+    public required string ToolName { get; set; }
+}
+
+/// <summary>The approval to add as a session-scoped rule.</summary>
+/// <remarks>Polymorphic base type discriminated by <c>kind</c>.</remarks>
+[JsonPolymorphic(
+    TypeDiscriminatorPropertyName = "kind",
+    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
+[JsonDerivedType(typeof(UserToolSessionApprovalCommands), "commands")]
+[JsonDerivedType(typeof(UserToolSessionApprovalRead), "read")]
+[JsonDerivedType(typeof(UserToolSessionApprovalWrite), "write")]
+[JsonDerivedType(typeof(UserToolSessionApprovalMcp), "mcp")]
+[JsonDerivedType(typeof(UserToolSessionApprovalMemory), "memory")]
+[JsonDerivedType(typeof(UserToolSessionApprovalCustomTool), "custom-tool")]
+public partial class UserToolSessionApproval
+{
+    /// <summary>The type discriminator.</summary>
+    [JsonPropertyName("kind")]
+    public virtual string Kind { get; set; } = string.Empty;
+}
+
+
+/// <summary>The <c>approved-for-session</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultApprovedForSession : PermissionResult
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "approved-for-session";
+
+    /// <summary>The approval to add as a session-scoped rule.</summary>
+    [JsonPropertyName("approval")]
+    public required UserToolSessionApproval Approval { get; set; }
+}
+
+/// <summary>The <c>approved-for-location</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultApprovedForLocation : PermissionResult
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "approved-for-location";
+
+    /// <summary>The approval to persist for this location.</summary>
+    [JsonPropertyName("approval")]
+    public required UserToolSessionApproval Approval { get; set; }
+
+    /// <summary>The location key (git root or cwd) to persist the approval to.</summary>
+    [JsonPropertyName("locationKey")]
+    public required string LocationKey { get; set; }
+}
+
+/// <summary>The <c>cancelled</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultCancelled : PermissionResult
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "cancelled";
+
+    /// <summary>Optional explanation of why the request was cancelled.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+}
+
+/// <summary>Nested data type for <c>PermissionRule</c>.</summary>
+public partial class PermissionRule
+{
+    /// <summary>Optional rule argument matched against the request.</summary>
+    [JsonPropertyName("argument")]
+    public string? Argument { get; set; }
+
+    /// <summary>The rule kind, such as Shell or GitHubMCP.</summary>
+    [JsonPropertyName("kind")]
+    public required string Kind { get; set; }
+}
+
+/// <summary>The <c>denied-by-rules</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultDeniedByRules : PermissionResult
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "denied-by-rules";
+
+    /// <summary>Rules that denied the request.</summary>
+    [JsonPropertyName("rules")]
+    public required PermissionRule[] Rules { get; set; }
+}
+
+/// <summary>The <c>denied-no-approval-rule-and-could-not-request-from-user</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultDeniedNoApprovalRuleAndCouldNotRequestFromUser : PermissionResult
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "denied-no-approval-rule-and-could-not-request-from-user";
+}
+
+/// <summary>The <c>denied-interactively-by-user</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultDeniedInteractivelyByUser : PermissionResult
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "denied-interactively-by-user";
+
+    /// <summary>Optional feedback from the user explaining the denial.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("feedback")]
+    public string? Feedback { get; set; }
+
+    /// <summary>Whether to force-reject the current agent turn.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("forceReject")]
+    public bool? ForceReject { get; set; }
+}
+
+/// <summary>The <c>denied-by-content-exclusion-policy</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultDeniedByContentExclusionPolicy : PermissionResult
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "denied-by-content-exclusion-policy";
+
+    /// <summary>Human-readable explanation of why the path was excluded.</summary>
+    [JsonPropertyName("message")]
+    public required string Message { get; set; }
+
+    /// <summary>File path that triggered the exclusion.</summary>
+    [JsonPropertyName("path")]
+    public required string Path { get; set; }
+}
+
+/// <summary>The <c>denied-by-permission-request-hook</c> variant of <see cref="PermissionResult"/>.</summary>
+public partial class PermissionResultDeniedByPermissionRequestHook : PermissionResult
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Kind => "denied-by-permission-request-hook";
+
+    /// <summary>Whether to interrupt the current agent turn.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("interrupt")]
+    public bool? Interrupt { get; set; }
+
+    /// <summary>Optional message from the hook explaining the denial.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}
+
+/// <summary>The result of the permission request.</summary>
+/// <remarks>Polymorphic base type discriminated by <c>kind</c>.</remarks>
+[JsonPolymorphic(
+    TypeDiscriminatorPropertyName = "kind",
+    UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToBaseType)]
+[JsonDerivedType(typeof(PermissionResultApproved), "approved")]
+[JsonDerivedType(typeof(PermissionResultApprovedForSession), "approved-for-session")]
+[JsonDerivedType(typeof(PermissionResultApprovedForLocation), "approved-for-location")]
+[JsonDerivedType(typeof(PermissionResultCancelled), "cancelled")]
+[JsonDerivedType(typeof(PermissionResultDeniedByRules), "denied-by-rules")]
+[JsonDerivedType(typeof(PermissionResultDeniedNoApprovalRuleAndCouldNotRequestFromUser), "denied-no-approval-rule-and-could-not-request-from-user")]
+[JsonDerivedType(typeof(PermissionResultDeniedInteractivelyByUser), "denied-interactively-by-user")]
+[JsonDerivedType(typeof(PermissionResultDeniedByContentExclusionPolicy), "denied-by-content-exclusion-policy")]
+[JsonDerivedType(typeof(PermissionResultDeniedByPermissionRequestHook), "denied-by-permission-request-hook")]
+public partial class PermissionResult
+{
+    /// <summary>The type discriminator.</summary>
+    [JsonPropertyName("kind")]
+    public virtual string Kind { get; set; } = string.Empty;
+}
+
 
 /// <summary>JSON Schema describing the form fields to present to the user (form mode only).</summary>
 /// <remarks>Nested data type for <c>ElicitationRequestedSchema</c>.</remarks>
@@ -4707,36 +5002,6 @@ public enum PermissionPromptRequestPathAccessKind
     Write,
 }
 
-/// <summary>The outcome of the permission request.</summary>
-[JsonConverter(typeof(JsonStringEnumConverter<PermissionCompletedKind>))]
-public enum PermissionCompletedKind
-{
-    /// <summary>The <c>approved</c> variant.</summary>
-    [JsonStringEnumMemberName("approved")]
-    Approved,
-    /// <summary>The <c>approved-for-session</c> variant.</summary>
-    [JsonStringEnumMemberName("approved-for-session")]
-    ApprovedForSession,
-    /// <summary>The <c>approved-for-location</c> variant.</summary>
-    [JsonStringEnumMemberName("approved-for-location")]
-    ApprovedForLocation,
-    /// <summary>The <c>denied-by-rules</c> variant.</summary>
-    [JsonStringEnumMemberName("denied-by-rules")]
-    DeniedByRules,
-    /// <summary>The <c>denied-no-approval-rule-and-could-not-request-from-user</c> variant.</summary>
-    [JsonStringEnumMemberName("denied-no-approval-rule-and-could-not-request-from-user")]
-    DeniedNoApprovalRuleAndCouldNotRequestFromUser,
-    /// <summary>The <c>denied-interactively-by-user</c> variant.</summary>
-    [JsonStringEnumMemberName("denied-interactively-by-user")]
-    DeniedInteractivelyByUser,
-    /// <summary>The <c>denied-by-content-exclusion-policy</c> variant.</summary>
-    [JsonStringEnumMemberName("denied-by-content-exclusion-policy")]
-    DeniedByContentExclusionPolicy,
-    /// <summary>The <c>denied-by-permission-request-hook</c> variant.</summary>
-    [JsonStringEnumMemberName("denied-by-permission-request-hook")]
-    DeniedByPermissionRequestHook,
-}
-
 /// <summary>Elicitation mode; "form" for structured input, "url" for browser-based. Defaults to "form" when absent.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<ElicitationRequestedMode>))]
 public enum ElicitationRequestedMode
@@ -4923,7 +5188,6 @@ public enum ExtensionsLoadedExtensionStatus
 [JsonSerializable(typeof(PendingMessagesModifiedEvent))]
 [JsonSerializable(typeof(PermissionCompletedData))]
 [JsonSerializable(typeof(PermissionCompletedEvent))]
-[JsonSerializable(typeof(PermissionCompletedResult))]
 [JsonSerializable(typeof(PermissionPromptRequest))]
 [JsonSerializable(typeof(PermissionPromptRequestCommands))]
 [JsonSerializable(typeof(PermissionPromptRequestCustomTool))]
@@ -4947,6 +5211,17 @@ public enum ExtensionsLoadedExtensionStatus
 [JsonSerializable(typeof(PermissionRequestWrite))]
 [JsonSerializable(typeof(PermissionRequestedData))]
 [JsonSerializable(typeof(PermissionRequestedEvent))]
+[JsonSerializable(typeof(PermissionResult))]
+[JsonSerializable(typeof(PermissionResultApproved))]
+[JsonSerializable(typeof(PermissionResultApprovedForLocation))]
+[JsonSerializable(typeof(PermissionResultApprovedForSession))]
+[JsonSerializable(typeof(PermissionResultCancelled))]
+[JsonSerializable(typeof(PermissionResultDeniedByContentExclusionPolicy))]
+[JsonSerializable(typeof(PermissionResultDeniedByPermissionRequestHook))]
+[JsonSerializable(typeof(PermissionResultDeniedByRules))]
+[JsonSerializable(typeof(PermissionResultDeniedInteractivelyByUser))]
+[JsonSerializable(typeof(PermissionResultDeniedNoApprovalRuleAndCouldNotRequestFromUser))]
+[JsonSerializable(typeof(PermissionRule))]
 [JsonSerializable(typeof(SamplingCompletedData))]
 [JsonSerializable(typeof(SamplingCompletedEvent))]
 [JsonSerializable(typeof(SamplingRequestedData))]
@@ -5011,7 +5286,9 @@ public enum ExtensionsLoadedExtensionStatus
 [JsonSerializable(typeof(ShutdownCodeChanges))]
 [JsonSerializable(typeof(ShutdownModelMetric))]
 [JsonSerializable(typeof(ShutdownModelMetricRequests))]
+[JsonSerializable(typeof(ShutdownModelMetricTokenDetail))]
 [JsonSerializable(typeof(ShutdownModelMetricUsage))]
+[JsonSerializable(typeof(ShutdownTokenDetail))]
 [JsonSerializable(typeof(SkillInvokedData))]
 [JsonSerializable(typeof(SkillInvokedEvent))]
 [JsonSerializable(typeof(SkillsLoadedSkill))]
@@ -5073,6 +5350,13 @@ public enum ExtensionsLoadedExtensionStatus
 [JsonSerializable(typeof(UserMessageAttachmentSelectionDetailsStart))]
 [JsonSerializable(typeof(UserMessageData))]
 [JsonSerializable(typeof(UserMessageEvent))]
+[JsonSerializable(typeof(UserToolSessionApproval))]
+[JsonSerializable(typeof(UserToolSessionApprovalCommands))]
+[JsonSerializable(typeof(UserToolSessionApprovalCustomTool))]
+[JsonSerializable(typeof(UserToolSessionApprovalMcp))]
+[JsonSerializable(typeof(UserToolSessionApprovalMemory))]
+[JsonSerializable(typeof(UserToolSessionApprovalRead))]
+[JsonSerializable(typeof(UserToolSessionApprovalWrite))]
 [JsonSerializable(typeof(WorkingDirectoryContext))]
 [JsonSerializable(typeof(JsonElement))]
 internal partial class SessionEventsJsonContext : JsonSerializerContext;

--- a/dotnet/src/Generated/SessionEvents.cs
+++ b/dotnet/src/Generated/SessionEvents.cs
@@ -3682,6 +3682,31 @@ public partial class SystemNotificationShellDetachedCompleted : SystemNotificati
     public required string ShellId { get; set; }
 }
 
+/// <summary>The <c>instruction_discovered</c> variant of <see cref="SystemNotification"/>.</summary>
+public partial class SystemNotificationInstructionDiscovered : SystemNotification
+{
+    /// <inheritdoc />
+    [JsonIgnore]
+    public override string Type => "instruction_discovered";
+
+    /// <summary>Human-readable label for the timeline (e.g., 'AGENTS.md from packages/billing/').</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>Relative path to the discovered instruction file.</summary>
+    [JsonPropertyName("sourcePath")]
+    public required string SourcePath { get; set; }
+
+    /// <summary>Path of the file access that triggered discovery.</summary>
+    [JsonPropertyName("triggerFile")]
+    public required string TriggerFile { get; set; }
+
+    /// <summary>Tool command that triggered discovery (currently always 'view').</summary>
+    [JsonPropertyName("triggerTool")]
+    public required string TriggerTool { get; set; }
+}
+
 /// <summary>Structured metadata identifying what triggered this notification.</summary>
 /// <remarks>Polymorphic base type discriminated by <c>type</c>.</remarks>
 [JsonPolymorphic(
@@ -3692,6 +3717,7 @@ public partial class SystemNotificationShellDetachedCompleted : SystemNotificati
 [JsonDerivedType(typeof(SystemNotificationNewInboxMessage), "new_inbox_message")]
 [JsonDerivedType(typeof(SystemNotificationShellCompleted), "shell_completed")]
 [JsonDerivedType(typeof(SystemNotificationShellDetachedCompleted), "shell_detached_completed")]
+[JsonDerivedType(typeof(SystemNotificationInstructionDiscovered), "instruction_discovered")]
 public partial class SystemNotification
 {
     /// <summary>The type discriminator.</summary>
@@ -5007,6 +5033,7 @@ public enum ExtensionsLoadedExtensionStatus
 [JsonSerializable(typeof(SystemNotificationAgentIdle))]
 [JsonSerializable(typeof(SystemNotificationData))]
 [JsonSerializable(typeof(SystemNotificationEvent))]
+[JsonSerializable(typeof(SystemNotificationInstructionDiscovered))]
 [JsonSerializable(typeof(SystemNotificationNewInboxMessage))]
 [JsonSerializable(typeof(SystemNotificationShellCompleted))]
 [JsonSerializable(typeof(SystemNotificationShellDetachedCompleted))]

--- a/dotnet/src/GitHub.Copilot.SDK.csproj
+++ b/dotnet/src/GitHub.Copilot.SDK.csproj
@@ -37,7 +37,6 @@
         <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
-        <PackageReference Include="StreamJsonRpc" PrivateAssets="compile" />
         <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 

--- a/dotnet/src/JsonRpc.cs
+++ b/dotnet/src/JsonRpc.cs
@@ -1,0 +1,835 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------------------------------------------*/
+
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using System.Text.Unicode;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace GitHub.Copilot.SDK;
+
+/// <summary>
+/// A lightweight JSON-RPC 2.0 implementation covering only the features used
+/// by this SDK to talk to the Copilot CLI. Messages are framed using the
+/// LSP-style header convention (<c>Content-Length: N\r\n\r\n</c> followed by
+/// N bytes of JSON body) — the same wire format used by the Language Server
+/// Protocol and the Copilot CLI's other language SDKs (Go, Node, Python).
+/// This is not a general-purpose JSON-RPC stack: it is narrowly scoped to the
+/// methods, transports, and framing the CLI uses.
+/// </summary>
+internal sealed partial class JsonRpc : IDisposable
+{
+    private const int ErrorCodeMethodNotFound = -32601;
+    private const int ErrorCodeInternalError = -32603;
+
+    private readonly Stream _sendStream;
+    private readonly Stream _receiveStream;
+    private readonly JsonSerializerOptions _serializerOptions;
+    private readonly ILogger _logger;
+    private readonly ConcurrentDictionary<long, PendingRequest> _pendingRequests = new();
+    private readonly ConcurrentDictionary<string, MethodRegistration> _methods = new();
+    private readonly TaskCompletionSource _completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly CancellationTokenSource _disposeCts = new();
+    private long _nextId;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new <see cref="JsonRpc"/>.
+    /// </summary>
+    /// <param name="sendStream">The stream to write outgoing messages to.</param>
+    /// <param name="receiveStream">The stream to read incoming messages from.</param>
+    /// <param name="serializerOptions">JSON serializer options (should include all needed source-gen contexts).</param>
+    /// <param name="logger">Optional logger for diagnostics.</param>
+    public JsonRpc(Stream sendStream, Stream receiveStream, JsonSerializerOptions serializerOptions, ILogger? logger = null)
+    {
+        _sendStream = sendStream;
+        _receiveStream = receiveStream;
+        _serializerOptions = serializerOptions;
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// A <see cref="Task"/> that completes when the connection is closed or faulted.
+    /// </summary>
+    public Task Completion => _completionSource.Task;
+
+    /// <summary>
+    /// Begins reading messages from the receive stream. Call once after registering all method handlers.
+    /// </summary>
+    public void StartListening()
+    {
+        _ = ReadLoopAsync(_disposeCts.Token);
+    }
+
+    /// <summary>
+    /// Sends a JSON-RPC request and waits for the response.
+    /// </summary>
+    public async Task<T> InvokeAsync<T>(string method, object?[]? args, CancellationToken cancellationToken)
+    {
+        var id = Interlocked.Increment(ref _nextId);
+        var pending = new PendingRequest();
+        _pendingRequests[id] = pending;
+
+        CancellationTokenRegistration cancelRegistration = default;
+        try
+        {
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancelRegistration = cancellationToken.Register(static state =>
+                {
+                    var (self, reqId, ct) = ((JsonRpc, long, CancellationToken))state!;
+                    if (self._pendingRequests.TryRemove(reqId, out var p))
+                    {
+                        p.TrySetCanceled(ct);
+                    }
+
+                    // Best-effort cancel notification
+                    _ = self.SendCancelNotificationAsync(reqId);
+                }, (this, id, cancellationToken));
+            }
+
+            // Send request message
+            await SendMessageAsync(new JsonRpcRequest
+            {
+                Id = id,
+                Method = method,
+                Params = SerializeArgs(args),
+            }, JsonRpcWireContext.Default.JsonRpcRequest, cancellationToken).ConfigureAwait(false);
+
+            var responseElement = await pending.Task.ConfigureAwait(false);
+
+            if (responseElement.ValueKind == JsonValueKind.Null || responseElement.ValueKind == JsonValueKind.Undefined)
+            {
+                return default!;
+            }
+
+            return (T)responseElement.Deserialize(_serializerOptions.GetTypeInfo(typeof(T)))!;
+        }
+        finally
+        {
+            _pendingRequests.TryRemove(id, out _);
+            await cancelRegistration.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Registers a method handler that receives positional parameters.
+    /// If singleObjectParam is false (the default), parameter names and types are inferred from the delegate's signature.
+    /// If singleObjectParam is true, the entire params object is deserialized as the handler's first parameter.
+    /// </summary>
+    public void SetLocalRpcMethod(string methodName, Delegate handler, bool singleObjectParam = false)
+    {
+        _methods[methodName] = new MethodRegistration(handler, singleObjectParam);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _disposeCts.Cancel();
+
+        // Fail all pending requests
+        foreach (var kvp in _pendingRequests)
+        {
+            if (_pendingRequests.TryRemove(kvp.Key, out var pending))
+            {
+                pending.TrySetException(new ObjectDisposedException(nameof(JsonRpc)));
+            }
+        }
+
+        _completionSource.TrySetResult();
+        _writeLock.Dispose();
+    }
+
+    private async Task SendMessageAsync<T>(T message, JsonTypeInfo<T> typeInfo, CancellationToken cancellationToken)
+    {
+        // "Content-Length: " (16) + max int digits (10) + "\r\n\r\n" (4)
+        const int MaxHeaderLength = 30;
+
+        var json = JsonSerializer.SerializeToUtf8Bytes(message, typeInfo);
+
+        var headerBuf = ArrayPool<byte>.Shared.Rent(MaxHeaderLength);
+        bool wrote = Utf8.TryWrite(headerBuf, $"Content-Length: {json.Length}\r\n\r\n", out int headerLen);
+        Debug.Assert(wrote && headerLen > 0);
+
+        // Cancellation only applies to *waiting* for the write lock. Once we hold the lock
+        // and start writing a framed message, we must finish it — cancelling between the
+        // header and the body (or mid-body) would leave the peer waiting for N body bytes
+        // that never arrive, desynchronizing the LSP-style stream for every subsequent
+        // message on this connection.
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _sendStream.WriteAsync(headerBuf.AsMemory(0, headerLen), CancellationToken.None).ConfigureAwait(false);
+            await _sendStream.WriteAsync(json, CancellationToken.None).ConfigureAwait(false);
+            await _sendStream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+            ArrayPool<byte>.Shared.Return(headerBuf);
+        }
+    }
+
+    private async Task ReadLoopAsync(CancellationToken cancellationToken)
+    {
+        var buffer = new byte[256];
+        int carried = 0; // bytes in buffer carried over from previous read
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // Read headers and body
+                var (contentLength, buf, newCarried) = await ReadMessageAsync(buffer, carried, cancellationToken).ConfigureAwait(false);
+                if (contentLength < 0)
+                {
+                    break; // Stream ended
+                }
+
+                // Keep the (possibly grown) buffer and carry-over count for next iteration
+                buffer = buf;
+                carried = newCarried;
+
+                // Parse the raw JSON. Body is at buffer[0..contentLength], carried bytes
+                // for the next message are at buffer[contentLength..contentLength+carried].
+                JsonElement? message = null;
+                try
+                {
+                    using var doc = JsonDocument.Parse(buffer.AsMemory(0, contentLength));
+                    message = doc.RootElement.Clone();
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse incoming JSON-RPC message");
+                }
+
+                // Always move carried bytes to the front, even on parse failure — otherwise
+                // the next ReadMessageAsync call would scan stale body bytes as headers.
+                // This must happen AFTER parsing because the carried region overlaps where
+                // the body lived.
+                if (carried > 0)
+                {
+                    Buffer.BlockCopy(buffer, contentLength, buffer, 0, carried);
+                }
+
+                if (message is not { } parsed)
+                {
+                    continue;
+                }
+
+                // Route the message
+                if (parsed.TryGetProperty("id", out var idProp) && !parsed.TryGetProperty("method", out _))
+                {
+                    // It's a response to one of our requests
+                    HandleResponse(parsed, idProp);
+                }
+                else if (parsed.TryGetProperty("method", out var methodProp) && methodProp.GetString() is string methodName)
+                {
+                    _ = HandleIncomingMethodAsync(methodName, parsed, cancellationToken);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Normal shutdown
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "JSON-RPC read loop ended");
+        }
+        finally
+        {
+            // Fail all pending requests
+            foreach (var kvp in _pendingRequests)
+            {
+                if (_pendingRequests.TryRemove(kvp.Key, out var pending))
+                {
+                    pending.TrySetException(new ConnectionLostException());
+                }
+            }
+
+            _completionSource.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Reads headers and body in one pass.
+    /// On return, body is at buffer[0..ContentLength], and any overflow bytes
+    /// from the next message are at buffer[ContentLength..ContentLength+Carried].
+    /// The caller must move the carried bytes to the front before the next call.
+    /// </summary>
+    /// <param name="buffer">Shared buffer (may be grown).</param>
+    /// <param name="carried">Bytes already in buffer[0..carried] from a previous read.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    private async ValueTask<(int ContentLength, byte[] Buffer, int Carried)> ReadMessageAsync(byte[] buffer, int carried, CancellationToken cancellationToken)
+    {
+        // Read until we find the \r\n\r\n header terminator.
+        // carried bytes are already at buffer[0..carried].
+        int filled = carried;
+        int headerEnd = -1; // index of first byte after \r\n\r\n
+
+        // Check carried bytes first for a header terminator
+        {
+            int pos = buffer.AsSpan(0, filled).IndexOf("\r\n\r\n"u8);
+            if (pos >= 0)
+            {
+                headerEnd = pos + 4;
+            }
+        }
+
+        while (headerEnd < 0)
+        {
+            if (filled == buffer.Length)
+            {
+                Array.Resize(ref buffer, buffer.Length * 2);
+            }
+
+            int bytesRead = await _receiveStream.ReadAsync(buffer.AsMemory(filled, buffer.Length - filled), cancellationToken).ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                // Clean EOF only if we haven't started a frame; otherwise the peer truncated mid-header.
+                if (filled == 0)
+                {
+                    return (-1, buffer, 0);
+                }
+
+                throw new EndOfStreamException("Stream ended while reading JSON-RPC headers.");
+            }
+
+            filled += bytesRead;
+
+            // Scan for \r\n\r\n starting from where a match could begin
+            int scanStart = Math.Max(filled - bytesRead - 3, 0);
+            int pos = buffer.AsSpan(scanStart, filled - scanStart).IndexOf("\r\n\r\n"u8);
+            if (pos >= 0)
+            {
+                headerEnd = scanStart + pos + 4;
+            }
+        }
+
+        // Parse Content-Length. LSP framing puts each header on its own \r\n-terminated
+        // line; we walk the lines and require an exact "Content-Length: " prefix at the
+        // start of one of them. A substring match anywhere in the header block would
+        // false-positive on values like "X-Trace: Content-Length: 5" and desync the stream.
+        // A missing or unparseable Content-Length means the framing is broken — there's
+        // no safe way to resync, so throw and let the read loop terminate the connection.
+        int contentLength = -1;
+        ReadOnlySpan<byte> prefix = "Content-Length: "u8;
+        // headerEnd points just past the \r\n\r\n terminator. Drop only the trailing
+        // empty line's \r\n; each remaining header line is still \r\n-terminated and
+        // gets split out by the IndexOf below.
+        var headerLines = buffer.AsSpan(0, headerEnd - 2);
+        while (!headerLines.IsEmpty)
+        {
+            int lineEnd = headerLines.IndexOf("\r\n"u8);
+            ReadOnlySpan<byte> line = lineEnd >= 0 ? headerLines.Slice(0, lineEnd) : headerLines;
+
+            if (line.StartsWith(prefix) &&
+                (contentLength >= 0 ||
+                 !int.TryParse(line.Slice(prefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out contentLength) ||
+                 contentLength < 0))
+            {
+                throw new InvalidDataException("JSON-RPC frame has a missing, duplicate, or invalid Content-Length header.");
+            }
+
+            headerLines = lineEnd >= 0 ? headerLines.Slice(lineEnd + 2) : default;
+        }
+
+        if (contentLength < 0)
+        {
+            throw new InvalidDataException("JSON-RPC frame is missing the Content-Length header.");
+        }
+
+        // Bytes after the header that we already have
+        int extraBytes = filled - headerEnd;
+
+        // Ensure buffer is large enough for the body and any overflow already read.
+        int needed = Math.Max(contentLength, extraBytes);
+        if (needed > buffer.Length)
+        {
+            var newBuffer = new byte[needed];
+            Buffer.BlockCopy(buffer, headerEnd, newBuffer, 0, extraBytes);
+            buffer = newBuffer;
+        }
+        else if (extraBytes > 0)
+        {
+            Buffer.BlockCopy(buffer, headerEnd, buffer, 0, extraBytes);
+        }
+
+        // Read remaining body bytes if we don't have enough
+        if (extraBytes < contentLength)
+        {
+            await _receiveStream.ReadExactlyAsync(buffer.AsMemory(extraBytes, contentLength - extraBytes), cancellationToken).ConfigureAwait(false);
+            return (contentLength, buffer, 0);
+        }
+
+        // We read more than the body — overflow belongs to the next message
+        int overflow = extraBytes - contentLength;
+        return (contentLength, buffer, overflow);
+    }
+
+    private void HandleResponse(JsonElement message, JsonElement idProp)
+    {
+        if (!idProp.TryGetInt64(out long id))
+        {
+            return;
+        }
+
+        if (!_pendingRequests.TryRemove(id, out var pending))
+        {
+            return;
+        }
+
+        if (message.TryGetProperty("error", out var errorProp))
+        {
+            var errorMessage = errorProp.TryGetProperty("message", out var msgProp)
+                ? msgProp.GetString() ?? "Unknown error"
+                : "Unknown error";
+            var errorCode = errorProp.TryGetProperty("code", out var codeProp) && codeProp.ValueKind == JsonValueKind.Number
+                ? codeProp.GetInt32()
+                : 0;
+            pending.TrySetException(new RemoteRpcException(errorMessage, errorCode));
+        }
+        else if (message.TryGetProperty("result", out var resultProp))
+        {
+            pending.TrySetResult(resultProp.Clone());
+        }
+        else
+        {
+            // Per JSON-RPC 2.0, a response must have either "result" or "error".
+            // Treat missing result as null result.
+            pending.TrySetResult(default);
+        }
+    }
+
+    private async Task HandleIncomingMethodAsync(string methodName, JsonElement message, CancellationToken cancellationToken)
+    {
+        try
+        {
+            JsonElement? requestId = null;
+            if (message.TryGetProperty("id", out var idProp))
+            {
+                requestId = idProp;
+            }
+
+            if (!_methods.TryGetValue(methodName, out var registration))
+            {
+                if (requestId.HasValue)
+                {
+                    await SendErrorResponseAsync(requestId.Value, ErrorCodeMethodNotFound, $"Method not found: {methodName}", cancellationToken).ConfigureAwait(false);
+                }
+                return;
+            }
+
+            message.TryGetProperty("params", out var paramsProp);
+
+            try
+            {
+                var result = await InvokeHandlerAsync(registration, paramsProp, cancellationToken).ConfigureAwait(false);
+
+                if (requestId.HasValue)
+                {
+                    await SendResultResponseAsync(requestId.Value, result, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Error handling JSON-RPC method {Method}: {Error}", methodName, ex.Message);
+                }
+                if (requestId.HasValue)
+                {
+                    await SendErrorResponseAsync(requestId.Value, ErrorCodeInternalError, ex.Message, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Normal shutdown — cancellation propagated from the read loop.
+        }
+        catch (Exception ex)
+        {
+            // Belt-and-braces: this method is fire-and-forget from the read loop, so any
+            // exception escaping here would become an unobserved task exception. The most
+            // likely sources are IOException/ObjectDisposedException from sending the error
+            // response after the underlying transport is gone.
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(ex, "Unobserved error in JSON-RPC method dispatch for {Method}", methodName);
+            }
+        }
+    }
+
+    private async ValueTask<object?> InvokeHandlerAsync(MethodRegistration registration, JsonElement paramsProp, CancellationToken cancellationToken)
+    {
+        var parameters = registration.Parameters;
+
+        // Build argument list
+        var invokeArgs = new object?[parameters.Length];
+
+        if (registration.SingleObjectParam)
+        {
+            // Single-object deserialization: entire `params` → first parameter.
+            // Every singleObjectParam handler has shape (TRequest, CancellationToken),
+            // so `params` must be a JSON object.
+            if (paramsProp.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidOperationException(
+                    $"Expected JSON object for `params` of single-object-param handler; got '{paramsProp.ValueKind}'.");
+            }
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (parameters[i].ParameterType == typeof(CancellationToken))
+                {
+                    invokeArgs[i] = cancellationToken;
+                }
+                else if (i == 0)
+                {
+                    invokeArgs[i] = paramsProp.Deserialize(_serializerOptions.GetTypeInfo(parameters[i].ParameterType));
+                }
+            }
+        }
+        else if (paramsProp.ValueKind == JsonValueKind.Array)
+        {
+            // Positional parameters. Optional params (with defaults) are filled when absent.
+            int jsonIndex = 0;
+            int arrayLength = paramsProp.GetArrayLength();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (parameters[i].ParameterType == typeof(CancellationToken))
+                {
+                    invokeArgs[i] = cancellationToken;
+                }
+                else if (jsonIndex < arrayLength)
+                {
+                    invokeArgs[i] = paramsProp[jsonIndex].Deserialize(_serializerOptions.GetTypeInfo(parameters[i].ParameterType));
+                    jsonIndex++;
+                }
+                else
+                {
+                    invokeArgs[i] = parameters[i].HasDefaultValue ? parameters[i].DefaultValue : null;
+                }
+            }
+        }
+        else if (paramsProp.ValueKind == JsonValueKind.Object)
+        {
+            // Named parameters. The CLI sends notifications/requests as a JSON object whose
+            // property names match the handler's parameter names (camelCased per web defaults).
+            // Look up each parameter by name; missing optional parameters fall back to defaults.
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (parameters[i].ParameterType == typeof(CancellationToken))
+                {
+                    invokeArgs[i] = cancellationToken;
+                }
+                else if (parameters[i].Name is { } paramName &&
+                         TryGetPropertyCaseInsensitive(paramsProp, paramName, out var valueProp))
+                {
+                    invokeArgs[i] = valueProp.Deserialize(_serializerOptions.GetTypeInfo(parameters[i].ParameterType));
+                }
+                else
+                {
+                    invokeArgs[i] = parameters[i].HasDefaultValue ? parameters[i].DefaultValue : null;
+                }
+            }
+        }
+        else
+        {
+            // Missing/null `params` for a handler with required positional parameters is a
+            // protocol violation. Surface it as an error rather than silently filling defaults.
+            throw new InvalidOperationException(
+                $"Unsupported JSON-RPC params shape '{paramsProp.ValueKind}' for handler with positional parameters.");
+        }
+
+        // Invoke
+        var result = registration.Handler.DynamicInvoke(invokeArgs);
+
+        // Handlers return one of: a synchronous value, Task (void async), or ValueTask<T>.
+        if (result is Task task)
+        {
+            // Task<T> handlers are not supported — use ValueTask<T> for results.
+            Debug.Assert(!task.GetType().IsGenericType, "Task<T> handlers are not supported; use ValueTask<T>.");
+            await task.ConfigureAwait(false);
+            return null;
+        }
+
+        if (result is not null && registration.ReturnsValueTaskOfT)
+        {
+            var resultType = result.GetType();
+            var asTask = (Task)resultType.GetMethod("AsTask")!.Invoke(result, null)!;
+            await asTask.ConfigureAwait(false);
+            return asTask.GetType().GetProperty("Result")!.GetValue(asTask);
+        }
+
+        return result;
+    }
+
+    private static bool TryGetPropertyCaseInsensitive(JsonElement obj, string name, out JsonElement value)
+    {
+        // Fast path: exact match. The CLI uses camelCase property names that match the
+        // C# parameter names exactly, so this should hit in the common case.
+        if (obj.TryGetProperty(name, out value))
+        {
+            return true;
+        }
+
+        foreach (var prop in obj.EnumerateObject())
+        {
+            if (string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                value = prop.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private JsonElement? SerializeArgs(object?[]? args)
+    {
+        if (args is null || args.Length == 0)
+        {
+            return null;
+        }
+
+        // The Copilot CLI uses vscode-jsonrpc-style request handlers, which expect
+        // `params` to be the single request object (not wrapped in a positional array).
+        // The other SDKs (Node, Python, Go) all send single-object params, and every
+        // generated call site here passes exactly one request object. For the rare
+        // multi-arg case, fall back to a positional array.
+        if (args.Length == 1)
+        {
+            var arg = args[0];
+            if (arg is null)
+            {
+                return null;
+            }
+
+            var typeInfo = _serializerOptions.GetTypeInfo(arg.GetType());
+            return JsonSerializer.SerializeToElement(arg, typeInfo);
+        }
+
+        // Source-generated JsonSerializerOptions do not provide metadata for object[],
+        // so build the JSON array manually, serializing each element with a TypeInfo
+        // looked up by its runtime type from the merged resolver.
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            foreach (var arg in args)
+            {
+                if (arg is null)
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    var typeInfo = _serializerOptions.GetTypeInfo(arg.GetType());
+                    JsonSerializer.Serialize(writer, arg, typeInfo);
+                }
+            }
+
+            writer.WriteEndArray();
+        }
+
+        using var doc = JsonDocument.Parse(buffer.WrittenMemory);
+        return doc.RootElement.Clone();
+    }
+
+    private async Task SendResultResponseAsync(JsonElement id, object? result, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Convert the result to a JsonElement using the runtime type, looked up via
+            // the merged resolver. Source-gen serialization of an `object`-typed property
+            // would otherwise have no way to find metadata for the actual response type
+            // (e.g. SystemMessageTransformRpcResponse, SessionFsReadFileResult, ...).
+            JsonElement? resultElement = null;
+            if (result is not null)
+            {
+                var typeInfo = _serializerOptions.GetTypeInfo(result.GetType());
+                resultElement = JsonSerializer.SerializeToElement(result, typeInfo);
+            }
+
+            await SendMessageAsync(new JsonRpcResponse
+            {
+                Id = id,
+                Result = resultElement,
+            }, JsonRpcWireContext.Default.JsonRpcResponse, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or OperationCanceledException)
+        {
+            // Connection lost during response — nothing we can do
+        }
+    }
+
+    private async Task SendErrorResponseAsync(JsonElement id, int code, string message, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await SendMessageAsync(new JsonRpcErrorResponse
+            {
+                Id = id,
+                Error = new JsonRpcError { Code = code, Message = message },
+            }, JsonRpcWireContext.Default.JsonRpcErrorResponse, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or OperationCanceledException)
+        {
+            // Connection lost during error response — nothing we can do
+        }
+    }
+
+    private async Task SendCancelNotificationAsync(long requestId)
+    {
+        try
+        {
+            await SendMessageAsync(new JsonRpcNotification
+            {
+                Method = "$/cancelRequest",
+                Params = JsonSerializer.SerializeToElement(
+                    new CancelRequestParams { Id = requestId },
+                    CancelRequestParamsContext.Default.CancelRequestParams),
+            }, JsonRpcWireContext.Default.JsonRpcNotification, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or OperationCanceledException)
+        {
+            // Best effort — connection may already be gone
+        }
+    }
+
+    private sealed class PendingRequest() : TaskCompletionSource<JsonElement>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private sealed class MethodRegistration
+    {
+        public MethodRegistration(Delegate handler, bool singleObjectParam)
+        {
+            Handler = handler;
+            SingleObjectParam = singleObjectParam;
+            Parameters = handler.Method.GetParameters();
+            ReturnsValueTaskOfT =
+                handler.Method.ReturnType.IsGenericType &&
+                handler.Method.ReturnType.GetGenericTypeDefinition() == typeof(ValueTask<>);
+        }
+
+        public Delegate Handler { get; }
+        public bool SingleObjectParam { get; }
+        public ParameterInfo[] Parameters { get; }
+        public bool ReturnsValueTaskOfT { get; }
+    }
+
+    [JsonSourceGenerationOptions(
+        JsonSerializerDefaults.Web,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(JsonRpcRequest))]
+    [JsonSerializable(typeof(JsonRpcResponse))]
+    [JsonSerializable(typeof(JsonRpcErrorResponse))]
+    [JsonSerializable(typeof(JsonRpcNotification))]
+    private partial class JsonRpcWireContext : JsonSerializerContext;
+
+    private sealed class JsonRpcRequest
+    {
+        [JsonPropertyName("jsonrpc")]
+        public string Jsonrpc { get; } = "2.0";
+
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+
+        [JsonPropertyName("method")]
+        public string Method { get; set; } = string.Empty;
+
+        [JsonPropertyName("params")]
+        public JsonElement? Params { get; set; }
+    }
+
+    private sealed class JsonRpcResponse
+    {
+        [JsonPropertyName("jsonrpc")]
+        public string Jsonrpc { get; } = "2.0";
+
+        [JsonPropertyName("id")]
+        public JsonElement Id { get; set; }
+
+        // JSON-RPC 2.0 requires every response to carry either `result` or `error`.
+        // vscode-jsonrpc (used by the CLI) rejects responses that have neither with
+        // "The received response has neither a result nor an error property", so we
+        // must emit `result: null` for void-returning handlers — overriding the
+        // context-level WhenWritingNull policy.
+        [JsonPropertyName("result")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+        public JsonElement? Result { get; set; }
+    }
+
+    private sealed class JsonRpcErrorResponse
+    {
+        [JsonPropertyName("jsonrpc")]
+        public string Jsonrpc { get; } = "2.0";
+
+        [JsonPropertyName("id")]
+        public JsonElement Id { get; set; }
+
+        [JsonPropertyName("error")]
+        public JsonRpcError? Error { get; set; }
+    }
+
+    private sealed class JsonRpcError
+    {
+        [JsonPropertyName("code")]
+        public int Code { get; set; }
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+    }
+
+    private sealed class JsonRpcNotification
+    {
+        [JsonPropertyName("jsonrpc")]
+        public string Jsonrpc { get; } = "2.0";
+
+        [JsonPropertyName("method")]
+        public string Method { get; set; } = string.Empty;
+
+        [JsonPropertyName("params")]
+        public JsonElement? Params { get; set; }
+    }
+
+    private sealed class CancelRequestParams
+    {
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+    }
+
+    [JsonSerializable(typeof(CancelRequestParams))]
+    private partial class CancelRequestParamsContext : JsonSerializerContext;
+}
+
+/// <summary>
+/// Thrown when the JSON-RPC connection is lost unexpectedly.
+/// </summary>
+internal sealed class ConnectionLostException() : IOException("The JSON-RPC connection was lost.");
+
+/// <summary>
+/// Thrown when the remote side returns a JSON-RPC error response.
+/// </summary>
+internal sealed class RemoteRpcException(string message, int errorCode, Exception? innerException = null) : Exception(message, innerException)
+{
+    public int ErrorCode { get; } = errorCode;
+}

--- a/dotnet/src/Session.cs
+++ b/dotnet/src/Session.cs
@@ -5,7 +5,6 @@
 using GitHub.Copilot.SDK.Rpc;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using StreamJsonRpc;
 using System.Collections.Immutable;
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -2005,6 +2005,7 @@ public class ResumeSessionConfig
         DisabledSkills = other.DisabledSkills is not null ? [.. other.DisabledSkills] : null;
         DisableResume = other.DisableResume;
         EnableConfigDiscovery = other.EnableConfigDiscovery;
+        ContinuePendingWork = other.ContinuePendingWork;
         ExcludedTools = other.ExcludedTools is not null ? [.. other.ExcludedTools] : null;
         Hooks = other.Hooks;
         InfiniteSessions = other.InfiniteSessions;
@@ -2139,6 +2140,20 @@ public class ResumeSessionConfig
     /// Default: false (resume event is emitted).
     /// </summary>
     public bool DisableResume { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, instructs the runtime to continue any tool calls
+    /// or permission prompts that were still pending when the session was last suspended.
+    /// When <see langword="false"/> (the default), the runtime treats pending work as
+    /// interrupted on resume.
+    /// <para>
+    /// For permission requests, the runtime re-emits <c>permission.requested</c> so the
+    /// registered <see cref="OnPermissionRequest"/> handler can re-prompt; for external
+    /// tool calls, the consumer is expected to supply the result via the corresponding
+    /// low-level RPC method.
+    /// </para>
+    /// </summary>
+    public bool? ContinuePendingWork { get; set; }
 
     /// <summary>
     /// Enable streaming of assistant message and reasoning chunks.

--- a/dotnet/src/Types.cs
+++ b/dotnet/src/Types.cs
@@ -1527,6 +1527,21 @@ public class AzureOptions
 // ============================================================================
 
 /// <summary>
+/// OAuth grant type for a remote MCP server.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<McpHttpServerConfigOauthGrantType>))]
+public enum McpHttpServerConfigOauthGrantType
+{
+    /// <summary>Use the authorization code OAuth flow.</summary>
+    [JsonStringEnumMemberName("authorization_code")]
+    AuthorizationCode,
+
+    /// <summary>Use the client credentials OAuth flow.</summary>
+    [JsonStringEnumMemberName("client_credentials")]
+    ClientCredentials
+}
+
+/// <summary>
 /// Abstract base class for MCP server configurations.
 /// </summary>
 [JsonPolymorphic(
@@ -1611,6 +1626,24 @@ public sealed class McpHttpServerConfig : McpServerConfig
     /// </summary>
     [JsonPropertyName("headers")]
     public IDictionary<string, string>? Headers { get; set; }
+
+    /// <summary>
+    /// Optional OAuth client ID for the remote server.
+    /// </summary>
+    [JsonPropertyName("oauthClientId")]
+    public string? OauthClientId { get; set; }
+
+    /// <summary>
+    /// Whether this is a public OAuth client.
+    /// </summary>
+    [JsonPropertyName("oauthPublicClient")]
+    public bool? OauthPublicClient { get; set; }
+
+    /// <summary>
+    /// Optional OAuth grant type for the remote server.
+    /// </summary>
+    [JsonPropertyName("oauthGrantType")]
+    public McpHttpServerConfigOauthGrantType? OauthGrantType { get; set; }
 }
 
 // ============================================================================

--- a/dotnet/test/CloneTests.cs
+++ b/dotnet/test/CloneTests.cs
@@ -303,4 +303,27 @@ public class CloneTests
 
         Assert.True(clone.IncludeSubAgentStreamingEvents);
     }
+
+    [Fact]
+    public void ResumeSessionConfig_Clone_CopiesContinuePendingWork()
+    {
+        var original = new ResumeSessionConfig
+        {
+            ContinuePendingWork = true,
+        };
+
+        var clone = original.Clone();
+
+        Assert.True(clone.ContinuePendingWork);
+    }
+
+    [Fact]
+    public void ResumeSessionConfig_Clone_PreservesContinuePendingWorkDefault()
+    {
+        var original = new ResumeSessionConfig();
+
+        var clone = original.Clone();
+
+        Assert.Null(clone.ContinuePendingWork);
+    }
 }

--- a/dotnet/test/GitHub.Copilot.SDK.Test.csproj
+++ b/dotnet/test/GitHub.Copilot.SDK.Test.csproj
@@ -26,7 +26,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/test/Harness/TestHelper.cs
+++ b/dotnet/test/Harness/TestHelper.cs
@@ -6,13 +6,19 @@ namespace GitHub.Copilot.SDK.Test.Harness;
 
 public static class TestHelper
 {
+    // Default tolerates CLI / replay-proxy cold start on Windows GitHub Actions
+    // runners, where the first test in a fixture can take ~60s before the first
+    // assistant message arrives. Subsequent tests in the same fixture typically
+    // complete in well under a second.
+    private static readonly TimeSpan DefaultEventTimeout = TimeSpan.FromSeconds(120);
+
     public static async Task<AssistantMessageEvent?> GetFinalAssistantMessageAsync(
         CopilotSession session,
         TimeSpan? timeout = null,
         bool alreadyIdle = false)
     {
         var tcs = new TaskCompletionSource<AssistantMessageEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
+        using var cts = new CancellationTokenSource(timeout ?? DefaultEventTimeout);
 
         // Both `finalAssistantMessage` and `sawIdle` are set from two threads — the
         // subscription callback (CLI read loop) and CheckExistingMessages (RPC reply).
@@ -111,7 +117,7 @@ public static class TestHelper
         TimeSpan? timeout = null) where T : SessionEvent
     {
         var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
+        using var cts = new CancellationTokenSource(timeout ?? DefaultEventTimeout);
 
         using var subscription = session.On(evt =>
         {

--- a/dotnet/test/Harness/TestHelper.cs
+++ b/dotnet/test/Harness/TestHelper.cs
@@ -14,17 +14,36 @@ public static class TestHelper
         var tcs = new TaskCompletionSource<AssistantMessageEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
         using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(60));
 
+        // Both `finalAssistantMessage` and `sawIdle` are set from two threads — the
+        // subscription callback (CLI read loop) and CheckExistingMessages (RPC reply).
+        // We complete only once we've observed both, regardless of which path saw which.
+        var stateLock = new object();
         AssistantMessageEvent? finalAssistantMessage = null;
+        bool sawIdle = false;
+
+        void TryComplete()
+        {
+            AssistantMessageEvent? snapshot;
+            bool idle;
+            lock (stateLock)
+            {
+                snapshot = finalAssistantMessage;
+                idle = sawIdle;
+            }
+            if (snapshot != null && idle) tcs.TrySetResult(snapshot);
+        }
 
         using var subscription = session.On(evt =>
         {
             switch (evt)
             {
                 case AssistantMessageEvent msg:
-                    finalAssistantMessage = msg;
+                    lock (stateLock) { finalAssistantMessage = msg; }
+                    TryComplete();
                     break;
-                case SessionIdleEvent when finalAssistantMessage != null:
-                    tcs.TrySetResult(finalAssistantMessage);
+                case SessionIdleEvent:
+                    lock (stateLock) { sawIdle = true; }
+                    TryComplete();
                     break;
                 case SessionErrorEvent error:
                     tcs.TrySetException(new Exception(error.Data.Message ?? "session error"));
@@ -32,7 +51,8 @@ public static class TestHelper
             }
         });
 
-        // Check existing messages
+        // Backfill from already-delivered messages so we don't lose events that arrived
+        // between SendAsync returning and the subscription being installed.
         CheckExistingMessages();
 
         cts.Token.Register(() => tcs.TrySetException(new TimeoutException("Timeout waiting for assistant message")));
@@ -43,8 +63,17 @@ public static class TestHelper
         {
             try
             {
-                var existing = await GetExistingFinalResponseAsync(session, alreadyIdle);
-                if (existing != null) tcs.TrySetResult(existing);
+                var (existingFinal, existingIdle) = await GetExistingMessagesAsync(session, alreadyIdle);
+                lock (stateLock)
+                {
+                    // Preserve a newer message captured by the subscription in the meantime.
+                    if (existingFinal != null && finalAssistantMessage == null)
+                    {
+                        finalAssistantMessage = existingFinal;
+                    }
+                    if (existingIdle) sawIdle = true;
+                }
+                TryComplete();
             }
             catch (Exception ex)
             {
@@ -53,7 +82,7 @@ public static class TestHelper
         }
     }
 
-    private static async Task<AssistantMessageEvent?> GetExistingFinalResponseAsync(CopilotSession session, bool alreadyIdle)
+    private static async Task<(AssistantMessageEvent? Final, bool SawIdle)> GetExistingMessagesAsync(CopilotSession session, bool alreadyIdle)
     {
         var messages = (await session.GetMessagesAsync()).ToList();
 
@@ -64,15 +93,17 @@ public static class TestHelper
         if (error != null) throw new Exception(error.Data.Message ?? "session error");
 
         var idleIdx = alreadyIdle ? currentTurn.Count : currentTurn.FindIndex(m => m is SessionIdleEvent);
-        if (idleIdx == -1) return null;
+        var sawIdle = alreadyIdle || idleIdx >= 0;
 
-        for (var i = idleIdx - 1; i >= 0; i--)
+        // Find the most recent assistant message in the turn (whether idle has arrived or not).
+        var searchEnd = idleIdx >= 0 ? idleIdx : currentTurn.Count;
+        for (var i = searchEnd - 1; i >= 0; i--)
         {
             if (currentTurn[i] is AssistantMessageEvent msg)
-                return msg;
+                return (msg, sawIdle);
         }
 
-        return null;
+        return (null, sawIdle);
     }
 
     public static async Task<T> GetNextEventOfTypeAsync<T>(

--- a/dotnet/test/McpAndAgentsTests.cs
+++ b/dotnet/test/McpAndAgentsTests.cs
@@ -324,7 +324,8 @@ public class McpAndAgentsTests(E2ETestFixture fixture, ITestOutputHelper output)
 
         await session.SendAsync(new MessageOptions { Prompt = "What is 7+7?" });
 
-        var message = await TestHelper.GetFinalAssistantMessageAsync(session);
+        // Use a longer timeout to tolerate slower MCP server spawning on Windows.
+        var message = await TestHelper.GetFinalAssistantMessageAsync(session, TimeSpan.FromSeconds(120));
         Assert.NotNull(message);
         Assert.Contains("14", message!.Data.Content);
 

--- a/dotnet/test/MultiClientTests.cs
+++ b/dotnet/test/MultiClientTests.cs
@@ -194,7 +194,7 @@ public class MultiClientTests : IClassFixture<MultiClientTestFixture>, IAsyncLif
         foreach (var evt in client1Events.OfType<PermissionCompletedEvent>()
             .Concat(client2Events.OfType<PermissionCompletedEvent>()))
         {
-            Assert.Equal(PermissionCompletedKind.Approved, evt.Data.Result.Kind);
+            Assert.IsType<PermissionResultApproved>(evt.Data.Result);
         }
 
         await session2.DisposeAsync();
@@ -246,7 +246,7 @@ public class MultiClientTests : IClassFixture<MultiClientTestFixture>, IAsyncLif
         foreach (var evt in client1Events.OfType<PermissionCompletedEvent>()
             .Concat(client2Events.OfType<PermissionCompletedEvent>()))
         {
-            Assert.Equal(PermissionCompletedKind.DeniedInteractivelyByUser, evt.Data.Result.Kind);
+            Assert.IsType<PermissionResultDeniedInteractivelyByUser>(evt.Data.Result);
         }
 
         await session2.DisposeAsync();

--- a/dotnet/test/SerializationTests.cs
+++ b/dotnet/test/SerializationTests.cs
@@ -5,68 +5,14 @@
 using Xunit;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Test;
 
 /// <summary>
-/// Tests for JSON serialization compatibility, particularly for StreamJsonRpc types
-/// that are needed when CancellationTokens fire during JSON-RPC operations.
-/// This test suite verifies the fix for https://github.com/PureWeen/PolyPilot/issues/319
+/// Tests for JSON serialization compatibility with the SDK's configured options.
 /// </summary>
 public class SerializationTests
 {
-    /// <summary>
-    /// Verifies that StreamJsonRpc.RequestId can be round-tripped using the SDK's configured
-    /// JsonSerializerOptions. This is critical for preventing NotSupportedException when
-    /// StandardCancellationStrategy fires during JSON-RPC operations.
-    /// </summary>
-    [Fact]
-    public void RequestId_CanBeSerializedAndDeserialized_WithSdkOptions()
-    {
-        var options = GetSerializerOptions();
-
-        // Long id
-        var jsonLong = JsonSerializer.Serialize(new RequestId(42L), options);
-        Assert.Equal("42", jsonLong);
-        Assert.Equal(new RequestId(42L), JsonSerializer.Deserialize<RequestId>(jsonLong, options));
-
-        // String id
-        var jsonStr = JsonSerializer.Serialize(new RequestId("req-1"), options);
-        Assert.Equal("\"req-1\"", jsonStr);
-        Assert.Equal(new RequestId("req-1"), JsonSerializer.Deserialize<RequestId>(jsonStr, options));
-
-        // Null id
-        var jsonNull = JsonSerializer.Serialize(RequestId.Null, options);
-        Assert.Equal("null", jsonNull);
-        Assert.Equal(RequestId.Null, JsonSerializer.Deserialize<RequestId>(jsonNull, options));
-    }
-
-    [Theory]
-    [InlineData(0L)]
-    [InlineData(-1L)]
-    [InlineData(long.MaxValue)]
-    public void RequestId_NumericEdgeCases_RoundTrip(long id)
-    {
-        var options = GetSerializerOptions();
-        var requestId = new RequestId(id);
-        var json = JsonSerializer.Serialize(requestId, options);
-        Assert.Equal(requestId, JsonSerializer.Deserialize<RequestId>(json, options));
-    }
-
-    /// <summary>
-    /// Verifies the SDK's options can resolve type info for RequestId,
-    /// ensuring AOT-safe serialization without falling back to reflection.
-    /// </summary>
-    [Fact]
-    public void SerializerOptions_CanResolveRequestIdTypeInfo()
-    {
-        var options = GetSerializerOptions();
-        var typeInfo = options.GetTypeInfo(typeof(RequestId));
-        Assert.NotNull(typeInfo);
-        Assert.Equal(typeof(RequestId), typeInfo.Type);
-    }
-
     [Fact]
     public void ProviderConfig_CanSerializeHeaders_WithSdkOptions()
     {

--- a/dotnet/test/SerializationTests.cs
+++ b/dotnet/test/SerializationTests.cs
@@ -81,6 +81,44 @@ public class SerializationTests
         Assert.Equal("trace-value", root.GetProperty("requestHeaders").GetProperty("X-Trace").GetString());
     }
 
+    [Fact]
+    public void McpHttpServerConfig_CanSerializeOauthOptions_WithSdkOptions()
+    {
+        var options = GetSerializerOptions();
+        McpServerConfig original = new McpHttpServerConfig
+        {
+            Url = "https://example.com/mcp",
+            Headers = new Dictionary<string, string> { ["Authorization"] = "Bearer token" },
+            OauthClientId = "client-id",
+            OauthPublicClient = false,
+            OauthGrantType = McpHttpServerConfigOauthGrantType.ClientCredentials,
+            Tools = ["*"],
+            Timeout = 3000
+        };
+
+        var json = JsonSerializer.Serialize(original, options);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.Equal("http", root.GetProperty("type").GetString());
+        Assert.Equal("https://example.com/mcp", root.GetProperty("url").GetString());
+        Assert.Equal("Bearer token", root.GetProperty("headers").GetProperty("Authorization").GetString());
+        Assert.Equal("client-id", root.GetProperty("oauthClientId").GetString());
+        Assert.False(root.GetProperty("oauthPublicClient").GetBoolean());
+        Assert.Equal("client_credentials", root.GetProperty("oauthGrantType").GetString());
+        Assert.Equal("*", root.GetProperty("tools")[0].GetString());
+        Assert.Equal(3000, root.GetProperty("timeout").GetInt32());
+
+        var deserialized = JsonSerializer.Deserialize<McpServerConfig>(json, options);
+        var httpConfig = Assert.IsType<McpHttpServerConfig>(deserialized);
+        Assert.Equal("https://example.com/mcp", httpConfig.Url);
+        Assert.Equal("Bearer token", httpConfig.Headers!["Authorization"]);
+        Assert.Equal("client-id", httpConfig.OauthClientId);
+        Assert.False(httpConfig.OauthPublicClient);
+        Assert.Equal(McpHttpServerConfigOauthGrantType.ClientCredentials, httpConfig.OauthGrantType);
+        Assert.Equal("*", Assert.Single(httpConfig.Tools));
+        Assert.Equal(3000, httpConfig.Timeout);
+    }
+
     private static JsonSerializerOptions GetSerializerOptions()
     {
         var prop = typeof(CopilotClient)

--- a/elixir/lib/copilot/client.ex
+++ b/elixir/lib/copilot/client.ex
@@ -165,6 +165,18 @@ defmodule Copilot.Client do
     GenServer.call(client, :get_last_session_id, 10_000)
   end
 
+  @doc "Get the foreground session ID."
+  @spec get_foreground_session_id(GenServer.server()) :: {:ok, String.t() | nil} | {:error, any()}
+  def get_foreground_session_id(client) do
+    GenServer.call(client, :get_foreground_session_id, 10_000)
+  end
+
+  @doc "Set the foreground session ID."
+  @spec set_foreground_session_id(GenServer.server(), String.t()) :: :ok | {:error, any()}
+  def set_foreground_session_id(client, session_id) do
+    GenServer.call(client, {:set_foreground_session_id, session_id}, 10_000)
+  end
+
   @doc "Get the current connection state."
   @spec get_state(GenServer.server()) :: :disconnected | :connecting | :connected | :error
   def get_state(client) do
@@ -343,6 +355,34 @@ defmodule Copilot.Client do
       {:ok, %{"sessionId" => sid}} -> {:reply, {:ok, sid}, state}
       {:ok, _} -> {:reply, {:ok, nil}, state}
       {:error, _} = err -> {:reply, err, state}
+    end
+  end
+
+  def handle_call(:get_foreground_session_id, _from, state) do
+    state = maybe_auto_start(state)
+
+    case JsonRpcClient.request(state.rpc, "session.getForeground", %{}) do
+      {:ok, %{"sessionId" => sid}} -> {:reply, {:ok, sid}, state}
+      {:ok, _} -> {:reply, {:ok, nil}, state}
+      {:error, _} = err -> {:reply, err, state}
+    end
+  end
+
+  def handle_call({:set_foreground_session_id, session_id}, _from, state) do
+    state = maybe_auto_start(state)
+
+    case JsonRpcClient.request(state.rpc, "session.setForeground", %{"sessionId" => session_id}) do
+      {:ok, %{"success" => true}} ->
+        {:reply, :ok, state}
+
+      {:ok, %{"success" => false, "error" => err}} ->
+        {:reply, {:error, "Failed to set foreground session: " <> err}, state}
+
+      {:ok, _} ->
+        {:reply, {:error, "Failed to set foreground session: Unknown error"}, state}
+
+      {:error, _} = err ->
+        {:reply, err, state}
     end
   end
 

--- a/fsharp/src/Client.fs
+++ b/fsharp/src/Client.fs
@@ -278,6 +278,25 @@ type CopilotClient(options: CopilotClientOptions) =
         sessions.TryRemove(sessionId) |> ignore
     }
 
+    /// Get the foreground session ID.
+    member _.GetForegroundSessionIdAsync(?cancellationToken: CancellationToken) : Async<string option> = async {
+        let t = getTransport ()
+        try
+            let! result = t.SendRequestAsync<{| sessionId: string option |}>("session.getForeground")
+            return result.sessionId
+        with
+        | :? JsonRpcException -> return None
+    }
+
+    /// Set the foreground session ID.
+    member _.SetForegroundSessionIdAsync(sessionId: string, ?cancellationToken: CancellationToken) : Async<unit> = async {
+        let t = getTransport ()
+        let! result = t.SendRequestAsync<{| success: bool; error: string option |}>("session.setForeground", {| sessionId = sessionId |})
+        if not result.success then
+            let errMsg = result.error |> Option.defaultValue "Unknown error"
+            failwithf "Failed to set foreground session: %s" errMsg
+    }
+
     // ------------------------------------------------------------------
     // IDisposable
     // ------------------------------------------------------------------

--- a/go/client.go
+++ b/go/client.go
@@ -779,6 +779,9 @@ func (c *Client) ResumeSessionWithOptions(ctx context.Context, sessionID string,
 	if config.DisableResume {
 		req.DisableResume = Bool(true)
 	}
+	if config.ContinuePendingWork {
+		req.ContinuePendingWork = Bool(true)
+	}
 	req.MCPServers = config.MCPServers
 	req.EnvValueMode = "direct"
 	req.CustomAgents = config.CustomAgents

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -881,6 +881,36 @@ func TestResumeSessionRequest_RequestElicitation(t *testing.T) {
 	})
 }
 
+func TestResumeSessionRequest_ContinuePendingWork(t *testing.T) {
+	t.Run("forwards continuePendingWork when true", func(t *testing.T) {
+		req := resumeSessionRequest{
+			SessionID:           "s1",
+			ContinuePendingWork: Bool(true),
+		}
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("Failed to marshal: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+		if m["continuePendingWork"] != true {
+			t.Errorf("Expected continuePendingWork to be true, got %v", m["continuePendingWork"])
+		}
+	})
+
+	t.Run("omits continuePendingWork when not set", func(t *testing.T) {
+		req := resumeSessionRequest{SessionID: "s1"}
+		data, _ := json.Marshal(req)
+		var m map[string]any
+		json.Unmarshal(data, &m)
+		if _, ok := m["continuePendingWork"]; ok {
+			t.Error("Expected continuePendingWork to be omitted when not set")
+		}
+	})
+}
+
 func TestCreateSessionRequest_IncludeSubAgentStreamingEvents(t *testing.T) {
 	t.Run("defaults to true when nil", func(t *testing.T) {
 		req := createSessionRequest{

--- a/go/generated_session_events.go
+++ b/go/generated_session_events.go
@@ -2071,10 +2071,16 @@ type SystemNotification struct {
 	SenderType *string `json:"senderType,omitempty"`
 	// Unique identifier of the shell session
 	ShellID *string `json:"shellId,omitempty"`
+	// Relative path to the discovered instruction file
+	SourcePath *string `json:"sourcePath,omitempty"`
 	// Whether the agent completed successfully or failed
 	Status *SystemNotificationAgentCompletedStatus `json:"status,omitempty"`
 	// Short summary shown before the agent decides whether to read the inbox
 	Summary *string `json:"summary,omitempty"`
+	// Path of the file access that triggered discovery
+	TriggerFile *string `json:"triggerFile,omitempty"`
+	// Tool command that triggered discovery (currently always 'view')
+	TriggerTool *string `json:"triggerTool,omitempty"`
 }
 
 // The result of the permission request
@@ -2444,6 +2450,7 @@ const (
 	SystemNotificationTypeNewInboxMessage        SystemNotificationType = "new_inbox_message"
 	SystemNotificationTypeShellCompleted         SystemNotificationType = "shell_completed"
 	SystemNotificationTypeShellDetachedCompleted SystemNotificationType = "shell_detached_completed"
+	SystemNotificationTypeInstructionDiscovered  SystemNotificationType = "instruction_discovered"
 )
 
 // Type discriminator for ToolExecutionCompleteContent.

--- a/go/generated_session_events.go
+++ b/go/generated_session_events.go
@@ -694,6 +694,8 @@ type AssistantMessageData struct {
 	RequestID *string `json:"requestId,omitempty"`
 	// Tool invocations requested by the assistant in this message
 	ToolRequests []AssistantMessageToolRequest `json:"toolRequests,omitempty"`
+	// Identifier for the agent loop turn that produced this message, matching the corresponding assistant.turn_start event
+	TurnID *string `json:"turnId,omitempty"`
 }
 
 func (*AssistantMessageData) sessionEventData() {}
@@ -1080,7 +1082,7 @@ type PermissionCompletedData struct {
 	// Request ID of the resolved permission request; clients should dismiss any UI for this request
 	RequestID string `json:"requestId"`
 	// The result of the permission request
-	Result PermissionCompletedResult `json:"result"`
+	Result PermissionResult `json:"result"`
 	// Optional tool call ID associated with this permission prompt; clients may use it to correlate UI created from tool-scoped prompts
 	ToolCallID *string `json:"toolCallId,omitempty"`
 }
@@ -1261,6 +1263,8 @@ type SessionResumeData struct {
 	AlreadyInUse *bool `json:"alreadyInUse,omitempty"`
 	// Updated working directory and git context at resume time
 	Context *WorkingDirectoryContext `json:"context,omitempty"`
+	// When true, tool calls and permission requests left in flight by the previous session lifetime remain pending after resume and the agentic loop awaits their results. User sends are queued behind the pending work until all such requests reach a terminal state. When false (the default), any such tool calls and permission requests are immediately marked as interrupted on resume.
+	ContinuePendingWork *bool `json:"continuePendingWork,omitempty"`
 	// Total number of persisted events in the session at the time of resume
 	EventCount float64 `json:"eventCount"`
 	// Reasoning effort level used for model calls, if applicable (e.g. "low", "medium", "high", "xhigh")
@@ -1271,6 +1275,8 @@ type SessionResumeData struct {
 	ResumeTime time.Time `json:"resumeTime"`
 	// Model currently selected at resume time
 	SelectedModel *string `json:"selectedModel,omitempty"`
+	// True when this resume attached to a session that the runtime already had running in-memory (for example, an extension joining a session another client was actively driving). False (or omitted) for cold resumes — the runtime had to reconstitute the session from its persisted event log.
+	SessionWasActive *bool `json:"sessionWasActive,omitempty"`
 }
 
 func (*SessionResumeData) sessionEventData() {}
@@ -1305,10 +1311,14 @@ type SessionShutdownData struct {
 	ShutdownType ShutdownType `json:"shutdownType"`
 	// System message token count at shutdown
 	SystemTokens *float64 `json:"systemTokens,omitempty"`
+	// Session-wide per-token-type accumulated token counts
+	TokenDetails map[string]ShutdownTokenDetail `json:"tokenDetails,omitempty"`
 	// Tool definitions token count at shutdown
 	ToolDefinitionsTokens *float64 `json:"toolDefinitionsTokens,omitempty"`
 	// Cumulative time spent in API calls during the session, in milliseconds
 	TotalAPIDurationMs float64 `json:"totalApiDurationMs"`
+	// Session-wide accumulated nano-AI units cost
+	TotalNanoAiu *float64 `json:"totalNanoAiu,omitempty"`
 	// Total number of premium API requests used during the session
 	TotalPremiumRequests float64 `json:"totalPremiumRequests"`
 }
@@ -1554,6 +1564,8 @@ type ToolExecutionCompleteData struct {
 	ToolCallID string `json:"toolCallId"`
 	// Tool-specific telemetry data (e.g., CodeQL check counts, grep match counts)
 	ToolTelemetry map[string]any `json:"toolTelemetry,omitempty"`
+	// Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event
+	TurnID *string `json:"turnId,omitempty"`
 }
 
 func (*ToolExecutionCompleteData) sessionEventData() {}
@@ -1583,6 +1595,8 @@ type ToolExecutionStartData struct {
 	ToolCallID string `json:"toolCallId"`
 	// Name of the tool being executed
 	ToolName string `json:"toolName"`
+	// Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event
+	TurnID *string `json:"turnId,omitempty"`
 }
 
 func (*ToolExecutionStartData) sessionEventData() {}
@@ -1665,6 +1679,8 @@ type UserMessageData struct {
 	InteractionID *string `json:"interactionId,omitempty"`
 	// Path-backed native document attachments that stayed on the tagged_files path flow because native upload would exceed the request size limit
 	NativeDocumentPathFallbackPaths []string `json:"nativeDocumentPathFallbackPaths,omitempty"`
+	// Parent agent task ID for background telemetry correlated to this user turn
+	ParentAgentTaskID *string `json:"parentAgentTaskId,omitempty"`
 	// Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user)
 	Source *string `json:"source,omitempty"`
 	// Normalized document MIME types that were sent natively instead of through tagged_files XML
@@ -1995,7 +2011,7 @@ type UserMessageAttachmentFileLineRange struct {
 type AssistantUsageCopilotUsage struct {
 	// Itemized token usage breakdown
 	TokenDetails []AssistantUsageCopilotUsageTokenDetail `json:"tokenDetails"`
-	// Total cost in nano-AIU (AI Units) for this request
+	// Total cost in nano-AI units for this request
 	TotalNanoAiu float64 `json:"totalNanoAiu"`
 }
 
@@ -2003,7 +2019,7 @@ type AssistantUsageCopilotUsage struct {
 type CompactionCompleteCompactionTokensUsedCopilotUsage struct {
 	// Itemized token usage breakdown
 	TokenDetails []CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail `json:"tokenDetails"`
-	// Total cost in nano-AIU (AI Units) for this request
+	// Total cost in nano-AI units for this request
 	TotalNanoAiu float64 `json:"totalNanoAiu"`
 }
 
@@ -2083,10 +2099,40 @@ type SystemNotification struct {
 	TriggerTool *string `json:"triggerTool,omitempty"`
 }
 
+// The approval to add as a session-scoped rule
+type UserToolSessionApproval struct {
+	// Kind discriminator
+	Kind UserToolSessionApprovalKind `json:"kind"`
+	// Command identifiers approved by the user
+	CommandIdentifiers []string `json:"commandIdentifiers,omitempty"`
+	// MCP server name
+	ServerName *string `json:"serverName,omitempty"`
+	// Optional MCP tool name, or null for all tools on the server
+	ToolName *string `json:"toolName,omitempty"`
+}
+
 // The result of the permission request
-type PermissionCompletedResult struct {
-	// The outcome of the permission request
-	Kind PermissionCompletedKind `json:"kind"`
+type PermissionResult struct {
+	// Kind discriminator
+	Kind PermissionResultKind `json:"kind"`
+	// The approval to add as a session-scoped rule
+	Approval *UserToolSessionApproval `json:"approval,omitempty"`
+	// Optional feedback from the user explaining the denial
+	Feedback *string `json:"feedback,omitempty"`
+	// Whether to force-reject the current agent turn
+	ForceReject *bool `json:"forceReject,omitempty"`
+	// Whether to interrupt the current agent turn
+	Interrupt *bool `json:"interrupt,omitempty"`
+	// The location key (git root or cwd) to persist the approval to
+	LocationKey *string `json:"locationKey,omitempty"`
+	// Human-readable explanation of why the path was excluded
+	Message *string `json:"message,omitempty"`
+	// File path that triggered the exclusion
+	Path *string `json:"path,omitempty"`
+	// Optional explanation of why the request was cancelled
+	Reason *string `json:"reason,omitempty"`
+	// Rules that denied the request
+	Rules []PermissionRule `json:"rules,omitempty"`
 }
 
 // Token usage breakdown
@@ -2258,11 +2304,32 @@ type PermissionRequestShellPossibleURL struct {
 	URL string `json:"url"`
 }
 
+type PermissionRule struct {
+	// Optional rule argument matched against the request
+	Argument *string `json:"argument"`
+	// The rule kind, such as Shell or GitHubMCP
+	Kind string `json:"kind"`
+}
+
 type ShutdownModelMetric struct {
 	// Request count and cost metrics
 	Requests ShutdownModelMetricRequests `json:"requests"`
+	// Token count details per type
+	TokenDetails map[string]ShutdownModelMetricTokenDetail `json:"tokenDetails,omitempty"`
+	// Accumulated nano-AI units cost for this model
+	TotalNanoAiu *float64 `json:"totalNanoAiu,omitempty"`
 	// Token usage breakdown
 	Usage ShutdownModelMetricUsage `json:"usage"`
+}
+
+type ShutdownModelMetricTokenDetail struct {
+	// Accumulated token count for this token type
+	TokenCount float64 `json:"tokenCount"`
+}
+
+type ShutdownTokenDetail struct {
+	// Accumulated token count for this token type
+	TokenCount float64 `json:"tokenCount"`
 }
 
 type SkillsLoadedSkill struct {
@@ -2355,6 +2422,33 @@ const (
 	PermissionRequestKindHook       PermissionRequestKind = "hook"
 )
 
+// Kind discriminator for PermissionResult.
+type PermissionResultKind string
+
+const (
+	PermissionResultKindApproved                                       PermissionResultKind = "approved"
+	PermissionResultKindApprovedForSession                             PermissionResultKind = "approved-for-session"
+	PermissionResultKindApprovedForLocation                            PermissionResultKind = "approved-for-location"
+	PermissionResultKindCancelled                                      PermissionResultKind = "cancelled"
+	PermissionResultKindDeniedByRules                                  PermissionResultKind = "denied-by-rules"
+	PermissionResultKindDeniedNoApprovalRuleAndCouldNotRequestFromUser PermissionResultKind = "denied-no-approval-rule-and-could-not-request-from-user"
+	PermissionResultKindDeniedInteractivelyByUser                      PermissionResultKind = "denied-interactively-by-user"
+	PermissionResultKindDeniedByContentExclusionPolicy                 PermissionResultKind = "denied-by-content-exclusion-policy"
+	PermissionResultKindDeniedByPermissionRequestHook                  PermissionResultKind = "denied-by-permission-request-hook"
+)
+
+// Kind discriminator for UserToolSessionApproval.
+type UserToolSessionApprovalKind string
+
+const (
+	UserToolSessionApprovalKindCommands   UserToolSessionApprovalKind = "commands"
+	UserToolSessionApprovalKindRead       UserToolSessionApprovalKind = "read"
+	UserToolSessionApprovalKindWrite      UserToolSessionApprovalKind = "write"
+	UserToolSessionApprovalKindMcp        UserToolSessionApprovalKind = "mcp"
+	UserToolSessionApprovalKindMemory     UserToolSessionApprovalKind = "memory"
+	UserToolSessionApprovalKindCustomTool UserToolSessionApprovalKind = "custom-tool"
+)
+
 // Message role: "system" for system prompts, "developer" for developer-injected instructions
 type SystemMessageRole string
 
@@ -2391,20 +2485,6 @@ const (
 	UserMessageAgentModePlan        UserMessageAgentMode = "plan"
 	UserMessageAgentModeAutopilot   UserMessageAgentMode = "autopilot"
 	UserMessageAgentModeShell       UserMessageAgentMode = "shell"
-)
-
-// The outcome of the permission request
-type PermissionCompletedKind string
-
-const (
-	PermissionCompletedKindApproved                                       PermissionCompletedKind = "approved"
-	PermissionCompletedKindApprovedForSession                             PermissionCompletedKind = "approved-for-session"
-	PermissionCompletedKindApprovedForLocation                            PermissionCompletedKind = "approved-for-location"
-	PermissionCompletedKindDeniedByRules                                  PermissionCompletedKind = "denied-by-rules"
-	PermissionCompletedKindDeniedNoApprovalRuleAndCouldNotRequestFromUser PermissionCompletedKind = "denied-no-approval-rule-and-could-not-request-from-user"
-	PermissionCompletedKindDeniedInteractivelyByUser                      PermissionCompletedKind = "denied-interactively-by-user"
-	PermissionCompletedKindDeniedByContentExclusionPolicy                 PermissionCompletedKind = "denied-by-content-exclusion-policy"
-	PermissionCompletedKindDeniedByPermissionRequestHook                  PermissionCompletedKind = "denied-by-permission-request-hook"
 )
 
 // The type of operation performed on the plan file

--- a/go/generated_session_events.go
+++ b/go/generated_session_events.go
@@ -2061,6 +2061,8 @@ type UserMessageAttachmentSelectionDetailsStart struct {
 type McpOauthRequiredStaticClientConfig struct {
 	// OAuth client ID for the server
 	ClientID string `json:"clientId"`
+	// Optional non-default OAuth grant type. When set to 'client_credentials', the OAuth flow runs headlessly using the client_id + keychain-stored secret (no browser, no callback server).
+	GrantType *string `json:"grantType,omitempty"`
 	// Whether this is a public OAuth client
 	PublicClient *bool `json:"publicClient,omitempty"`
 }

--- a/go/internal/e2e/streaming_fidelity_test.go
+++ b/go/internal/e2e/streaming_fidelity_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -25,8 +26,11 @@ func TestStreamingFidelity(t *testing.T) {
 		}
 
 		var events []copilot.SessionEvent
+		var mu sync.Mutex
 		session.On(func(event copilot.SessionEvent) {
+			mu.Lock()
 			events = append(events, event)
+			mu.Unlock()
 		})
 
 		_, err = session.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "Count from 1 to 5, separated by commas."})
@@ -34,9 +38,14 @@ func TestStreamingFidelity(t *testing.T) {
 			t.Fatalf("Failed to send message: %v", err)
 		}
 
+		mu.Lock()
+		snapshot := make([]copilot.SessionEvent, len(events))
+		copy(snapshot, events)
+		mu.Unlock()
+
 		// Should have streaming deltas before the final message
 		var deltaEvents []copilot.SessionEvent
-		for _, e := range events {
+		for _, e := range snapshot {
 			if e.Type == "assistant.message_delta" {
 				deltaEvents = append(deltaEvents, e)
 			}
@@ -54,7 +63,7 @@ func TestStreamingFidelity(t *testing.T) {
 
 		// Should still have a final assistant.message
 		hasAssistantMessage := false
-		for _, e := range events {
+		for _, e := range snapshot {
 			if e.Type == "assistant.message" {
 				hasAssistantMessage = true
 				break
@@ -67,7 +76,7 @@ func TestStreamingFidelity(t *testing.T) {
 		// Deltas should come before the final message
 		firstDeltaIdx := -1
 		lastAssistantIdx := -1
-		for i, e := range events {
+		for i, e := range snapshot {
 			if e.Type == "assistant.message_delta" && firstDeltaIdx == -1 {
 				firstDeltaIdx = i
 			}
@@ -92,8 +101,11 @@ func TestStreamingFidelity(t *testing.T) {
 		}
 
 		var events []copilot.SessionEvent
+		var mu sync.Mutex
 		session.On(func(event copilot.SessionEvent) {
+			mu.Lock()
 			events = append(events, event)
+			mu.Unlock()
 		})
 
 		_, err = session.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "Say 'hello world'."})
@@ -101,9 +113,14 @@ func TestStreamingFidelity(t *testing.T) {
 			t.Fatalf("Failed to send message: %v", err)
 		}
 
+		mu.Lock()
+		snapshot := make([]copilot.SessionEvent, len(events))
+		copy(snapshot, events)
+		mu.Unlock()
+
 		// No deltas when streaming is off
 		var deltaEvents []copilot.SessionEvent
-		for _, e := range events {
+		for _, e := range snapshot {
 			if e.Type == "assistant.message_delta" {
 				deltaEvents = append(deltaEvents, e)
 			}
@@ -114,7 +131,7 @@ func TestStreamingFidelity(t *testing.T) {
 
 		// But should still have a final assistant.message
 		var assistantEvents []copilot.SessionEvent
-		for _, e := range events {
+		for _, e := range snapshot {
 			if e.Type == "assistant.message" {
 				assistantEvents = append(assistantEvents, e)
 			}
@@ -153,8 +170,11 @@ func TestStreamingFidelity(t *testing.T) {
 		}
 
 		var events []copilot.SessionEvent
+		var mu sync.Mutex
 		session2.On(func(event copilot.SessionEvent) {
+			mu.Lock()
 			events = append(events, event)
+			mu.Unlock()
 		})
 
 		answer, err := session2.SendAndWait(t.Context(), copilot.MessageOptions{Prompt: "Now if you double that, what do you get?"})
@@ -167,9 +187,14 @@ func TestStreamingFidelity(t *testing.T) {
 			t.Errorf("Expected answer to contain '18', got %v", answer)
 		}
 
+		mu.Lock()
+		snapshot := make([]copilot.SessionEvent, len(events))
+		copy(snapshot, events)
+		mu.Unlock()
+
 		// Should have streaming deltas before the final message
 		var deltaEvents []copilot.SessionEvent
-		for _, e := range events {
+		for _, e := range snapshot {
 			if e.Type == "assistant.message_delta" {
 				deltaEvents = append(deltaEvents, e)
 			}

--- a/go/rpc/generated_rpc.go
+++ b/go/rpc/generated_rpc.go
@@ -13,233 +13,248 @@ import (
 )
 
 type RPCTypes struct {
-	AccountGetQuotaRequest                                  AccountGetQuotaRequest                                  `json:"AccountGetQuotaRequest"`
-	AccountGetQuotaResult                                   AccountGetQuotaResult                                   `json:"AccountGetQuotaResult"`
-	AccountQuotaSnapshot                                    AccountQuotaSnapshot                                    `json:"AccountQuotaSnapshot"`
-	AgentDeselectResult                                     AgentDeselectResult                                     `json:"AgentDeselectResult"`
-	AgentGetCurrentResult                                   AgentGetCurrentResult                                   `json:"AgentGetCurrentResult"`
-	AgentInfo                                               AgentInfo                                               `json:"AgentInfo"`
-	AgentList                                               AgentList                                               `json:"AgentList"`
-	AgentReloadResult                                       AgentReloadResult                                       `json:"AgentReloadResult"`
-	AgentSelectRequest                                      AgentSelectRequest                                      `json:"AgentSelectRequest"`
-	AgentSelectResult                                       AgentSelectResult                                       `json:"AgentSelectResult"`
-	AuthInfoType                                            AuthInfoType                                            `json:"AuthInfoType"`
-	CommandsHandlePendingCommandRequest                     CommandsHandlePendingCommandRequest                     `json:"CommandsHandlePendingCommandRequest"`
-	CommandsHandlePendingCommandResult                      CommandsHandlePendingCommandResult                      `json:"CommandsHandlePendingCommandResult"`
-	CurrentModel                                            CurrentModel                                            `json:"CurrentModel"`
-	DiscoveredMCPServer                                     DiscoveredMCPServer                                     `json:"DiscoveredMcpServer"`
-	DiscoveredMCPServerSource                               MCPServerSource                                         `json:"DiscoveredMcpServerSource"`
-	DiscoveredMCPServerType                                 DiscoveredMCPServerType                                 `json:"DiscoveredMcpServerType"`
-	Extension                                               Extension                                               `json:"Extension"`
-	ExtensionList                                           ExtensionList                                           `json:"ExtensionList"`
-	ExtensionsDisableRequest                                ExtensionsDisableRequest                                `json:"ExtensionsDisableRequest"`
-	ExtensionsDisableResult                                 ExtensionsDisableResult                                 `json:"ExtensionsDisableResult"`
-	ExtensionsEnableRequest                                 ExtensionsEnableRequest                                 `json:"ExtensionsEnableRequest"`
-	ExtensionsEnableResult                                  ExtensionsEnableResult                                  `json:"ExtensionsEnableResult"`
-	ExtensionSource                                         ExtensionSource                                         `json:"ExtensionSource"`
-	ExtensionsReloadResult                                  ExtensionsReloadResult                                  `json:"ExtensionsReloadResult"`
-	ExtensionStatus                                         ExtensionStatus                                         `json:"ExtensionStatus"`
-	FilterMapping                                           *FilterMapping                                          `json:"FilterMapping"`
-	FilterMappingString                                     FilterMappingString                                     `json:"FilterMappingString"`
-	FilterMappingValue                                      FilterMappingString                                     `json:"FilterMappingValue"`
-	FleetStartRequest                                       FleetStartRequest                                       `json:"FleetStartRequest"`
-	FleetStartResult                                        FleetStartResult                                        `json:"FleetStartResult"`
-	HandleToolCallResult                                    HandleToolCallResult                                    `json:"HandleToolCallResult"`
-	HistoryCompactContextWindow                             HistoryCompactContextWindow                             `json:"HistoryCompactContextWindow"`
-	HistoryCompactResult                                    HistoryCompactResult                                    `json:"HistoryCompactResult"`
-	HistoryTruncateRequest                                  HistoryTruncateRequest                                  `json:"HistoryTruncateRequest"`
-	HistoryTruncateResult                                   HistoryTruncateResult                                   `json:"HistoryTruncateResult"`
-	InstructionsGetSourcesResult                            InstructionsGetSourcesResult                            `json:"InstructionsGetSourcesResult"`
-	InstructionsSources                                     InstructionsSources                                     `json:"InstructionsSources"`
-	InstructionsSourcesLocation                             InstructionsSourcesLocation                             `json:"InstructionsSourcesLocation"`
-	InstructionsSourcesType                                 InstructionsSourcesType                                 `json:"InstructionsSourcesType"`
-	LogRequest                                              LogRequest                                              `json:"LogRequest"`
-	LogResult                                               LogResult                                               `json:"LogResult"`
-	MCPConfigAddRequest                                     MCPConfigAddRequest                                     `json:"McpConfigAddRequest"`
-	MCPConfigAddResult                                      MCPConfigAddResult                                      `json:"McpConfigAddResult"`
-	MCPConfigDisableRequest                                 MCPConfigDisableRequest                                 `json:"McpConfigDisableRequest"`
-	MCPConfigDisableResult                                  MCPConfigDisableResult                                  `json:"McpConfigDisableResult"`
-	MCPConfigEnableRequest                                  MCPConfigEnableRequest                                  `json:"McpConfigEnableRequest"`
-	MCPConfigEnableResult                                   MCPConfigEnableResult                                   `json:"McpConfigEnableResult"`
-	MCPConfigList                                           MCPConfigList                                           `json:"McpConfigList"`
-	MCPConfigRemoveRequest                                  MCPConfigRemoveRequest                                  `json:"McpConfigRemoveRequest"`
-	MCPConfigRemoveResult                                   MCPConfigRemoveResult                                   `json:"McpConfigRemoveResult"`
-	MCPConfigUpdateRequest                                  MCPConfigUpdateRequest                                  `json:"McpConfigUpdateRequest"`
-	MCPConfigUpdateResult                                   MCPConfigUpdateResult                                   `json:"McpConfigUpdateResult"`
-	MCPDisableRequest                                       MCPDisableRequest                                       `json:"McpDisableRequest"`
-	MCPDisableResult                                        MCPDisableResult                                        `json:"McpDisableResult"`
-	MCPDiscoverRequest                                      MCPDiscoverRequest                                      `json:"McpDiscoverRequest"`
-	MCPDiscoverResult                                       MCPDiscoverResult                                       `json:"McpDiscoverResult"`
-	MCPEnableRequest                                        MCPEnableRequest                                        `json:"McpEnableRequest"`
-	MCPEnableResult                                         MCPEnableResult                                         `json:"McpEnableResult"`
-	MCPOauthLoginRequest                                    MCPOauthLoginRequest                                    `json:"McpOauthLoginRequest"`
-	MCPOauthLoginResult                                     MCPOauthLoginResult                                     `json:"McpOauthLoginResult"`
-	MCPReloadResult                                         MCPReloadResult                                         `json:"McpReloadResult"`
-	MCPServer                                               MCPServer                                               `json:"McpServer"`
-	MCPServerConfig                                         MCPServerConfig                                         `json:"McpServerConfig"`
-	MCPServerConfigHTTP                                     MCPServerConfigHTTP                                     `json:"McpServerConfigHttp"`
-	MCPServerConfigHTTPType                                 MCPServerConfigHTTPType                                 `json:"McpServerConfigHttpType"`
-	MCPServerConfigLocal                                    MCPServerConfigLocal                                    `json:"McpServerConfigLocal"`
-	MCPServerConfigLocalType                                MCPServerConfigLocalType                                `json:"McpServerConfigLocalType"`
-	MCPServerList                                           MCPServerList                                           `json:"McpServerList"`
-	MCPServerSource                                         MCPServerSource                                         `json:"McpServerSource"`
-	MCPServerStatus                                         MCPServerStatus                                         `json:"McpServerStatus"`
-	Model                                                   ModelElement                                            `json:"Model"`
-	ModelBilling                                            ModelBilling                                            `json:"ModelBilling"`
-	ModelCapabilities                                       ModelCapabilities                                       `json:"ModelCapabilities"`
-	ModelCapabilitiesLimits                                 ModelCapabilitiesLimits                                 `json:"ModelCapabilitiesLimits"`
-	ModelCapabilitiesLimitsVision                           ModelCapabilitiesLimitsVision                           `json:"ModelCapabilitiesLimitsVision"`
-	ModelCapabilitiesOverride                               ModelCapabilitiesOverride                               `json:"ModelCapabilitiesOverride"`
-	ModelCapabilitiesOverrideLimits                         ModelCapabilitiesOverrideLimits                         `json:"ModelCapabilitiesOverrideLimits"`
-	ModelCapabilitiesOverrideLimitsVision                   ModelCapabilitiesOverrideLimitsVision                   `json:"ModelCapabilitiesOverrideLimitsVision"`
-	ModelCapabilitiesOverrideSupports                       ModelCapabilitiesOverrideSupports                       `json:"ModelCapabilitiesOverrideSupports"`
-	ModelCapabilitiesSupports                               ModelCapabilitiesSupports                               `json:"ModelCapabilitiesSupports"`
-	ModelList                                               ModelList                                               `json:"ModelList"`
-	ModelPolicy                                             ModelPolicy                                             `json:"ModelPolicy"`
-	ModelsListRequest                                       ModelsListRequest                                       `json:"ModelsListRequest"`
-	ModelSwitchToRequest                                    ModelSwitchToRequest                                    `json:"ModelSwitchToRequest"`
-	ModelSwitchToResult                                     ModelSwitchToResult                                     `json:"ModelSwitchToResult"`
-	ModeSetRequest                                          ModeSetRequest                                          `json:"ModeSetRequest"`
-	ModeSetResult                                           ModeSetResult                                           `json:"ModeSetResult"`
-	NameGetResult                                           NameGetResult                                           `json:"NameGetResult"`
-	NameSetRequest                                          NameSetRequest                                          `json:"NameSetRequest"`
-	NameSetResult                                           NameSetResult                                           `json:"NameSetResult"`
-	PermissionDecision                                      PermissionDecision                                      `json:"PermissionDecision"`
-	PermissionDecisionApproveForLocation                    PermissionDecisionApproveForLocation                    `json:"PermissionDecisionApproveForLocation"`
-	PermissionDecisionApproveForLocationApproval            PermissionDecisionApproveForLocationApproval            `json:"PermissionDecisionApproveForLocationApproval"`
-	PermissionDecisionApproveForLocationApprovalCommands    PermissionDecisionApproveForLocationApprovalCommands    `json:"PermissionDecisionApproveForLocationApprovalCommands"`
-	PermissionDecisionApproveForLocationApprovalCustomTool  PermissionDecisionApproveForLocationApprovalCustomTool  `json:"PermissionDecisionApproveForLocationApprovalCustomTool"`
-	PermissionDecisionApproveForLocationApprovalMCP         PermissionDecisionApproveForLocationApprovalMCP         `json:"PermissionDecisionApproveForLocationApprovalMcp"`
-	PermissionDecisionApproveForLocationApprovalMCPSampling PermissionDecisionApproveForLocationApprovalMCPSampling `json:"PermissionDecisionApproveForLocationApprovalMcpSampling"`
-	PermissionDecisionApproveForLocationApprovalMemory      PermissionDecisionApproveForLocationApprovalMemory      `json:"PermissionDecisionApproveForLocationApprovalMemory"`
-	PermissionDecisionApproveForLocationApprovalRead        PermissionDecisionApproveForLocationApprovalRead        `json:"PermissionDecisionApproveForLocationApprovalRead"`
-	PermissionDecisionApproveForLocationApprovalWrite       PermissionDecisionApproveForLocationApprovalWrite       `json:"PermissionDecisionApproveForLocationApprovalWrite"`
-	PermissionDecisionApproveForSession                     PermissionDecisionApproveForSession                     `json:"PermissionDecisionApproveForSession"`
-	PermissionDecisionApproveForSessionApproval             PermissionDecisionApproveForSessionApproval             `json:"PermissionDecisionApproveForSessionApproval"`
-	PermissionDecisionApproveForSessionApprovalCommands     PermissionDecisionApproveForSessionApprovalCommands     `json:"PermissionDecisionApproveForSessionApprovalCommands"`
-	PermissionDecisionApproveForSessionApprovalCustomTool   PermissionDecisionApproveForSessionApprovalCustomTool   `json:"PermissionDecisionApproveForSessionApprovalCustomTool"`
-	PermissionDecisionApproveForSessionApprovalMCP          PermissionDecisionApproveForSessionApprovalMCP          `json:"PermissionDecisionApproveForSessionApprovalMcp"`
-	PermissionDecisionApproveForSessionApprovalMCPSampling  PermissionDecisionApproveForSessionApprovalMCPSampling  `json:"PermissionDecisionApproveForSessionApprovalMcpSampling"`
-	PermissionDecisionApproveForSessionApprovalMemory       PermissionDecisionApproveForSessionApprovalMemory       `json:"PermissionDecisionApproveForSessionApprovalMemory"`
-	PermissionDecisionApproveForSessionApprovalRead         PermissionDecisionApproveForSessionApprovalRead         `json:"PermissionDecisionApproveForSessionApprovalRead"`
-	PermissionDecisionApproveForSessionApprovalWrite        PermissionDecisionApproveForSessionApprovalWrite        `json:"PermissionDecisionApproveForSessionApprovalWrite"`
-	PermissionDecisionApproveOnce                           PermissionDecisionApproveOnce                           `json:"PermissionDecisionApproveOnce"`
-	PermissionDecisionReject                                PermissionDecisionReject                                `json:"PermissionDecisionReject"`
-	PermissionDecisionRequest                               PermissionDecisionRequest                               `json:"PermissionDecisionRequest"`
-	PermissionDecisionUserNotAvailable                      PermissionDecisionUserNotAvailable                      `json:"PermissionDecisionUserNotAvailable"`
-	PermissionRequestResult                                 PermissionRequestResult                                 `json:"PermissionRequestResult"`
-	PermissionsResetSessionApprovalsRequest                 PermissionsResetSessionApprovalsRequest                 `json:"PermissionsResetSessionApprovalsRequest"`
-	PermissionsResetSessionApprovalsResult                  PermissionsResetSessionApprovalsResult                  `json:"PermissionsResetSessionApprovalsResult"`
-	PermissionsSetApproveAllRequest                         PermissionsSetApproveAllRequest                         `json:"PermissionsSetApproveAllRequest"`
-	PermissionsSetApproveAllResult                          PermissionsSetApproveAllResult                          `json:"PermissionsSetApproveAllResult"`
-	PingRequest                                             PingRequest                                             `json:"PingRequest"`
-	PingResult                                              PingResult                                              `json:"PingResult"`
-	PlanDeleteResult                                        PlanDeleteResult                                        `json:"PlanDeleteResult"`
-	PlanReadResult                                          PlanReadResult                                          `json:"PlanReadResult"`
-	PlanUpdateRequest                                       PlanUpdateRequest                                       `json:"PlanUpdateRequest"`
-	PlanUpdateResult                                        PlanUpdateResult                                        `json:"PlanUpdateResult"`
-	Plugin                                                  PluginElement                                           `json:"Plugin"`
-	PluginList                                              PluginList                                              `json:"PluginList"`
-	ServerSkill                                             ServerSkill                                             `json:"ServerSkill"`
-	ServerSkillList                                         ServerSkillList                                         `json:"ServerSkillList"`
-	SessionAuthStatus                                       SessionAuthStatus                                       `json:"SessionAuthStatus"`
-	SessionFSAppendFileRequest                              SessionFSAppendFileRequest                              `json:"SessionFsAppendFileRequest"`
-	SessionFSError                                          SessionFSError                                          `json:"SessionFsError"`
-	SessionFSErrorCode                                      SessionFSErrorCode                                      `json:"SessionFsErrorCode"`
-	SessionFSExistsRequest                                  SessionFSExistsRequest                                  `json:"SessionFsExistsRequest"`
-	SessionFSExistsResult                                   SessionFSExistsResult                                   `json:"SessionFsExistsResult"`
-	SessionFSMkdirRequest                                   SessionFSMkdirRequest                                   `json:"SessionFsMkdirRequest"`
-	SessionFSReaddirRequest                                 SessionFSReaddirRequest                                 `json:"SessionFsReaddirRequest"`
-	SessionFSReaddirResult                                  SessionFSReaddirResult                                  `json:"SessionFsReaddirResult"`
-	SessionFSReaddirWithTypesEntry                          SessionFSReaddirWithTypesEntry                          `json:"SessionFsReaddirWithTypesEntry"`
-	SessionFSReaddirWithTypesEntryType                      SessionFSReaddirWithTypesEntryType                      `json:"SessionFsReaddirWithTypesEntryType"`
-	SessionFSReaddirWithTypesRequest                        SessionFSReaddirWithTypesRequest                        `json:"SessionFsReaddirWithTypesRequest"`
-	SessionFSReaddirWithTypesResult                         SessionFSReaddirWithTypesResult                         `json:"SessionFsReaddirWithTypesResult"`
-	SessionFSReadFileRequest                                SessionFSReadFileRequest                                `json:"SessionFsReadFileRequest"`
-	SessionFSReadFileResult                                 SessionFSReadFileResult                                 `json:"SessionFsReadFileResult"`
-	SessionFSRenameRequest                                  SessionFSRenameRequest                                  `json:"SessionFsRenameRequest"`
-	SessionFSRmRequest                                      SessionFSRmRequest                                      `json:"SessionFsRmRequest"`
-	SessionFSSetProviderConventions                         SessionFSSetProviderConventions                         `json:"SessionFsSetProviderConventions"`
-	SessionFSSetProviderRequest                             SessionFSSetProviderRequest                             `json:"SessionFsSetProviderRequest"`
-	SessionFSSetProviderResult                              SessionFSSetProviderResult                              `json:"SessionFsSetProviderResult"`
-	SessionFSStatRequest                                    SessionFSStatRequest                                    `json:"SessionFsStatRequest"`
-	SessionFSStatResult                                     SessionFSStatResult                                     `json:"SessionFsStatResult"`
-	SessionFSWriteFileRequest                               SessionFSWriteFileRequest                               `json:"SessionFsWriteFileRequest"`
-	SessionLogLevel                                         SessionLogLevel                                         `json:"SessionLogLevel"`
-	SessionMode                                             SessionMode                                             `json:"SessionMode"`
-	SessionsForkRequest                                     SessionsForkRequest                                     `json:"SessionsForkRequest"`
-	SessionsForkResult                                      SessionsForkResult                                      `json:"SessionsForkResult"`
-	ShellExecRequest                                        ShellExecRequest                                        `json:"ShellExecRequest"`
-	ShellExecResult                                         ShellExecResult                                         `json:"ShellExecResult"`
-	ShellKillRequest                                        ShellKillRequest                                        `json:"ShellKillRequest"`
-	ShellKillResult                                         ShellKillResult                                         `json:"ShellKillResult"`
-	ShellKillSignal                                         ShellKillSignal                                         `json:"ShellKillSignal"`
-	Skill                                                   Skill                                                   `json:"Skill"`
-	SkillList                                               SkillList                                               `json:"SkillList"`
-	SkillsConfigSetDisabledSkillsRequest                    SkillsConfigSetDisabledSkillsRequest                    `json:"SkillsConfigSetDisabledSkillsRequest"`
-	SkillsConfigSetDisabledSkillsResult                     SkillsConfigSetDisabledSkillsResult                     `json:"SkillsConfigSetDisabledSkillsResult"`
-	SkillsDisableRequest                                    SkillsDisableRequest                                    `json:"SkillsDisableRequest"`
-	SkillsDisableResult                                     SkillsDisableResult                                     `json:"SkillsDisableResult"`
-	SkillsDiscoverRequest                                   SkillsDiscoverRequest                                   `json:"SkillsDiscoverRequest"`
-	SkillsEnableRequest                                     SkillsEnableRequest                                     `json:"SkillsEnableRequest"`
-	SkillsEnableResult                                      SkillsEnableResult                                      `json:"SkillsEnableResult"`
-	SkillsReloadResult                                      SkillsReloadResult                                      `json:"SkillsReloadResult"`
-	TaskAgentInfo                                           TaskAgentInfo                                           `json:"TaskAgentInfo"`
-	TaskAgentInfoExecutionMode                              TaskInfoExecutionMode                                   `json:"TaskAgentInfoExecutionMode"`
-	TaskAgentInfoStatus                                     TaskInfoStatus                                          `json:"TaskAgentInfoStatus"`
-	TaskInfo                                                TaskInfo                                                `json:"TaskInfo"`
-	TaskList                                                TaskList                                                `json:"TaskList"`
-	TasksCancelRequest                                      TasksCancelRequest                                      `json:"TasksCancelRequest"`
-	TasksCancelResult                                       TasksCancelResult                                       `json:"TasksCancelResult"`
-	TaskShellInfo                                           TaskShellInfo                                           `json:"TaskShellInfo"`
-	TaskShellInfoAttachmentMode                             TaskShellInfoAttachmentMode                             `json:"TaskShellInfoAttachmentMode"`
-	TaskShellInfoExecutionMode                              TaskInfoExecutionMode                                   `json:"TaskShellInfoExecutionMode"`
-	TaskShellInfoStatus                                     TaskInfoStatus                                          `json:"TaskShellInfoStatus"`
-	TasksPromoteToBackgroundRequest                         TasksPromoteToBackgroundRequest                         `json:"TasksPromoteToBackgroundRequest"`
-	TasksPromoteToBackgroundResult                          TasksPromoteToBackgroundResult                          `json:"TasksPromoteToBackgroundResult"`
-	TasksRemoveRequest                                      TasksRemoveRequest                                      `json:"TasksRemoveRequest"`
-	TasksRemoveResult                                       TasksRemoveResult                                       `json:"TasksRemoveResult"`
-	TasksStartAgentRequest                                  TasksStartAgentRequest                                  `json:"TasksStartAgentRequest"`
-	TasksStartAgentResult                                   TasksStartAgentResult                                   `json:"TasksStartAgentResult"`
-	Tool                                                    Tool                                                    `json:"Tool"`
-	ToolCallResult                                          ToolCallResult                                          `json:"ToolCallResult"`
-	ToolList                                                ToolList                                                `json:"ToolList"`
-	ToolsHandlePendingToolCall                              *ToolsHandlePendingToolCall                             `json:"ToolsHandlePendingToolCall"`
-	ToolsHandlePendingToolCallRequest                       ToolsHandlePendingToolCallRequest                       `json:"ToolsHandlePendingToolCallRequest"`
-	ToolsListRequest                                        ToolsListRequest                                        `json:"ToolsListRequest"`
-	UIElicitationArrayAnyOfField                            UIElicitationArrayAnyOfField                            `json:"UIElicitationArrayAnyOfField"`
-	UIElicitationArrayAnyOfFieldItems                       UIElicitationArrayAnyOfFieldItems                       `json:"UIElicitationArrayAnyOfFieldItems"`
-	UIElicitationArrayAnyOfFieldItemsAnyOf                  UIElicitationArrayAnyOfFieldItemsAnyOf                  `json:"UIElicitationArrayAnyOfFieldItemsAnyOf"`
-	UIElicitationArrayEnumField                             UIElicitationArrayEnumField                             `json:"UIElicitationArrayEnumField"`
-	UIElicitationArrayEnumFieldItems                        UIElicitationArrayEnumFieldItems                        `json:"UIElicitationArrayEnumFieldItems"`
-	UIElicitationFieldValue                                 *UIElicitationFieldValue                                `json:"UIElicitationFieldValue"`
-	UIElicitationRequest                                    UIElicitationRequest                                    `json:"UIElicitationRequest"`
-	UIElicitationResponse                                   UIElicitationResponse                                   `json:"UIElicitationResponse"`
-	UIElicitationResponseAction                             UIElicitationResponseAction                             `json:"UIElicitationResponseAction"`
-	UIElicitationResponseContent                            map[string]*UIElicitationFieldValue                     `json:"UIElicitationResponseContent"`
-	UIElicitationResult                                     UIElicitationResult                                     `json:"UIElicitationResult"`
-	UIElicitationSchema                                     UIElicitationSchema                                     `json:"UIElicitationSchema"`
-	UIElicitationSchemaProperty                             UIElicitationSchemaProperty                             `json:"UIElicitationSchemaProperty"`
-	UIElicitationSchemaPropertyBoolean                      UIElicitationSchemaPropertyBoolean                      `json:"UIElicitationSchemaPropertyBoolean"`
-	UIElicitationSchemaPropertyNumber                       UIElicitationSchemaPropertyNumber                       `json:"UIElicitationSchemaPropertyNumber"`
-	UIElicitationSchemaPropertyNumberType                   UIElicitationSchemaPropertyNumberTypeEnum               `json:"UIElicitationSchemaPropertyNumberType"`
-	UIElicitationSchemaPropertyString                       UIElicitationSchemaPropertyString                       `json:"UIElicitationSchemaPropertyString"`
-	UIElicitationSchemaPropertyStringFormat                 UIElicitationSchemaPropertyStringFormat                 `json:"UIElicitationSchemaPropertyStringFormat"`
-	UIElicitationStringEnumField                            UIElicitationStringEnumField                            `json:"UIElicitationStringEnumField"`
-	UIElicitationStringOneOfField                           UIElicitationStringOneOfField                           `json:"UIElicitationStringOneOfField"`
-	UIElicitationStringOneOfFieldOneOf                      UIElicitationStringOneOfFieldOneOf                      `json:"UIElicitationStringOneOfFieldOneOf"`
-	UIHandlePendingElicitationRequest                       UIHandlePendingElicitationRequest                       `json:"UIHandlePendingElicitationRequest"`
-	UsageGetMetricsResult                                   UsageGetMetricsResult                                   `json:"UsageGetMetricsResult"`
-	UsageMetricsCodeChanges                                 UsageMetricsCodeChanges                                 `json:"UsageMetricsCodeChanges"`
-	UsageMetricsModelMetric                                 UsageMetricsModelMetric                                 `json:"UsageMetricsModelMetric"`
-	UsageMetricsModelMetricRequests                         UsageMetricsModelMetricRequests                         `json:"UsageMetricsModelMetricRequests"`
-	UsageMetricsModelMetricUsage                            UsageMetricsModelMetricUsage                            `json:"UsageMetricsModelMetricUsage"`
-	WorkspacesCreateFileRequest                             WorkspacesCreateFileRequest                             `json:"WorkspacesCreateFileRequest"`
-	WorkspacesCreateFileResult                              WorkspacesCreateFileResult                              `json:"WorkspacesCreateFileResult"`
-	WorkspacesGetWorkspaceResult                            WorkspacesGetWorkspaceResult                            `json:"WorkspacesGetWorkspaceResult"`
-	WorkspacesListFilesResult                               WorkspacesListFilesResult                               `json:"WorkspacesListFilesResult"`
-	WorkspacesReadFileRequest                               WorkspacesReadFileRequest                               `json:"WorkspacesReadFileRequest"`
-	WorkspacesReadFileResult                                WorkspacesReadFileResult                                `json:"WorkspacesReadFileResult"`
+	AccountGetQuotaRequest                                   AccountGetQuotaRequest                                   `json:"AccountGetQuotaRequest"`
+	AccountGetQuotaResult                                    AccountGetQuotaResult                                    `json:"AccountGetQuotaResult"`
+	AccountQuotaSnapshot                                     AccountQuotaSnapshot                                     `json:"AccountQuotaSnapshot"`
+	AgentDeselectResult                                      AgentDeselectResult                                      `json:"AgentDeselectResult"`
+	AgentGetCurrentResult                                    AgentGetCurrentResult                                    `json:"AgentGetCurrentResult"`
+	AgentInfo                                                AgentInfo                                                `json:"AgentInfo"`
+	AgentList                                                AgentList                                                `json:"AgentList"`
+	AgentReloadResult                                        AgentReloadResult                                        `json:"AgentReloadResult"`
+	AgentSelectRequest                                       AgentSelectRequest                                       `json:"AgentSelectRequest"`
+	AgentSelectResult                                        AgentSelectResult                                        `json:"AgentSelectResult"`
+	AuthInfoType                                             AuthInfoType                                             `json:"AuthInfoType"`
+	CommandsHandlePendingCommandRequest                      CommandsHandlePendingCommandRequest                      `json:"CommandsHandlePendingCommandRequest"`
+	CommandsHandlePendingCommandResult                       CommandsHandlePendingCommandResult                       `json:"CommandsHandlePendingCommandResult"`
+	CurrentModel                                             CurrentModel                                             `json:"CurrentModel"`
+	DiscoveredMCPServer                                      DiscoveredMCPServer                                      `json:"DiscoveredMcpServer"`
+	DiscoveredMCPServerSource                                MCPServerSource                                          `json:"DiscoveredMcpServerSource"`
+	DiscoveredMCPServerType                                  DiscoveredMCPServerType                                  `json:"DiscoveredMcpServerType"`
+	EmbeddedBlobResourceContents                             EmbeddedBlobResourceContents                             `json:"EmbeddedBlobResourceContents"`
+	EmbeddedTextResourceContents                             EmbeddedTextResourceContents                             `json:"EmbeddedTextResourceContents"`
+	Extension                                                Extension                                                `json:"Extension"`
+	ExtensionList                                            ExtensionList                                            `json:"ExtensionList"`
+	ExtensionsDisableRequest                                 ExtensionsDisableRequest                                 `json:"ExtensionsDisableRequest"`
+	ExtensionsDisableResult                                  ExtensionsDisableResult                                  `json:"ExtensionsDisableResult"`
+	ExtensionsEnableRequest                                  ExtensionsEnableRequest                                  `json:"ExtensionsEnableRequest"`
+	ExtensionsEnableResult                                   ExtensionsEnableResult                                   `json:"ExtensionsEnableResult"`
+	ExtensionSource                                          ExtensionSource                                          `json:"ExtensionSource"`
+	ExtensionsReloadResult                                   ExtensionsReloadResult                                   `json:"ExtensionsReloadResult"`
+	ExtensionStatus                                          ExtensionStatus                                          `json:"ExtensionStatus"`
+	ExternalToolResult                                       *ExternalToolResult                                      `json:"ExternalToolResult"`
+	ExternalToolTextResultForLlm                             ExternalToolTextResultForLlm                             `json:"ExternalToolTextResultForLlm"`
+	ExternalToolTextResultForLlmContent                      ExternalToolTextResultForLlmContent                      `json:"ExternalToolTextResultForLlmContent"`
+	ExternalToolTextResultForLlmContentAudio                 ExternalToolTextResultForLlmContentAudio                 `json:"ExternalToolTextResultForLlmContentAudio"`
+	ExternalToolTextResultForLlmContentImage                 ExternalToolTextResultForLlmContentImage                 `json:"ExternalToolTextResultForLlmContentImage"`
+	ExternalToolTextResultForLlmContentResource              ExternalToolTextResultForLlmContentResource              `json:"ExternalToolTextResultForLlmContentResource"`
+	ExternalToolTextResultForLlmContentResourceDetails       ExternalToolTextResultForLlmContentResourceDetails       `json:"ExternalToolTextResultForLlmContentResourceDetails"`
+	ExternalToolTextResultForLlmContentResourceLink          ExternalToolTextResultForLlmContentResourceLink          `json:"ExternalToolTextResultForLlmContentResourceLink"`
+	ExternalToolTextResultForLlmContentResourceLinkIcon      ExternalToolTextResultForLlmContentResourceLinkIcon      `json:"ExternalToolTextResultForLlmContentResourceLinkIcon"`
+	ExternalToolTextResultForLlmContentResourceLinkIconTheme ExternalToolTextResultForLlmContentResourceLinkIconTheme `json:"ExternalToolTextResultForLlmContentResourceLinkIconTheme"`
+	ExternalToolTextResultForLlmContentTerminal              ExternalToolTextResultForLlmContentTerminal              `json:"ExternalToolTextResultForLlmContentTerminal"`
+	ExternalToolTextResultForLlmContentText                  ExternalToolTextResultForLlmContentText                  `json:"ExternalToolTextResultForLlmContentText"`
+	FilterMapping                                            *FilterMapping                                           `json:"FilterMapping"`
+	FilterMappingString                                      FilterMappingString                                      `json:"FilterMappingString"`
+	FilterMappingValue                                       FilterMappingString                                      `json:"FilterMappingValue"`
+	FleetStartRequest                                        FleetStartRequest                                        `json:"FleetStartRequest"`
+	FleetStartResult                                         FleetStartResult                                         `json:"FleetStartResult"`
+	HandlePendingToolCallRequest                             HandlePendingToolCallRequest                             `json:"HandlePendingToolCallRequest"`
+	HandlePendingToolCallResult                              HandlePendingToolCallResult                              `json:"HandlePendingToolCallResult"`
+	HistoryCompactContextWindow                              HistoryCompactContextWindow                              `json:"HistoryCompactContextWindow"`
+	HistoryCompactResult                                     HistoryCompactResult                                     `json:"HistoryCompactResult"`
+	HistoryTruncateRequest                                   HistoryTruncateRequest                                   `json:"HistoryTruncateRequest"`
+	HistoryTruncateResult                                    HistoryTruncateResult                                    `json:"HistoryTruncateResult"`
+	InstructionsGetSourcesResult                             InstructionsGetSourcesResult                             `json:"InstructionsGetSourcesResult"`
+	InstructionsSources                                      InstructionsSources                                      `json:"InstructionsSources"`
+	InstructionsSourcesLocation                              InstructionsSourcesLocation                              `json:"InstructionsSourcesLocation"`
+	InstructionsSourcesType                                  InstructionsSourcesType                                  `json:"InstructionsSourcesType"`
+	LogRequest                                               LogRequest                                               `json:"LogRequest"`
+	LogResult                                                LogResult                                                `json:"LogResult"`
+	MCPConfigAddRequest                                      MCPConfigAddRequest                                      `json:"McpConfigAddRequest"`
+	MCPConfigAddResult                                       MCPConfigAddResult                                       `json:"McpConfigAddResult"`
+	MCPConfigDisableRequest                                  MCPConfigDisableRequest                                  `json:"McpConfigDisableRequest"`
+	MCPConfigDisableResult                                   MCPConfigDisableResult                                   `json:"McpConfigDisableResult"`
+	MCPConfigEnableRequest                                   MCPConfigEnableRequest                                   `json:"McpConfigEnableRequest"`
+	MCPConfigEnableResult                                    MCPConfigEnableResult                                    `json:"McpConfigEnableResult"`
+	MCPConfigList                                            MCPConfigList                                            `json:"McpConfigList"`
+	MCPConfigRemoveRequest                                   MCPConfigRemoveRequest                                   `json:"McpConfigRemoveRequest"`
+	MCPConfigRemoveResult                                    MCPConfigRemoveResult                                    `json:"McpConfigRemoveResult"`
+	MCPConfigUpdateRequest                                   MCPConfigUpdateRequest                                   `json:"McpConfigUpdateRequest"`
+	MCPConfigUpdateResult                                    MCPConfigUpdateResult                                    `json:"McpConfigUpdateResult"`
+	MCPDisableRequest                                        MCPDisableRequest                                        `json:"McpDisableRequest"`
+	MCPDisableResult                                         MCPDisableResult                                         `json:"McpDisableResult"`
+	MCPDiscoverRequest                                       MCPDiscoverRequest                                       `json:"McpDiscoverRequest"`
+	MCPDiscoverResult                                        MCPDiscoverResult                                        `json:"McpDiscoverResult"`
+	MCPEnableRequest                                         MCPEnableRequest                                         `json:"McpEnableRequest"`
+	MCPEnableResult                                          MCPEnableResult                                          `json:"McpEnableResult"`
+	MCPOauthLoginRequest                                     MCPOauthLoginRequest                                     `json:"McpOauthLoginRequest"`
+	MCPOauthLoginResult                                      MCPOauthLoginResult                                      `json:"McpOauthLoginResult"`
+	MCPReloadResult                                          MCPReloadResult                                          `json:"McpReloadResult"`
+	MCPServer                                                MCPServer                                                `json:"McpServer"`
+	MCPServerConfig                                          MCPServerConfig                                          `json:"McpServerConfig"`
+	MCPServerConfigHTTP                                      MCPServerConfigHTTP                                      `json:"McpServerConfigHttp"`
+	MCPServerConfigHTTPType                                  MCPServerConfigHTTPType                                  `json:"McpServerConfigHttpType"`
+	MCPServerConfigLocal                                     MCPServerConfigLocal                                     `json:"McpServerConfigLocal"`
+	MCPServerConfigLocalType                                 MCPServerConfigLocalType                                 `json:"McpServerConfigLocalType"`
+	MCPServerList                                            MCPServerList                                            `json:"McpServerList"`
+	MCPServerSource                                          MCPServerSource                                          `json:"McpServerSource"`
+	MCPServerStatus                                          MCPServerStatus                                          `json:"McpServerStatus"`
+	Model                                                    ModelElement                                             `json:"Model"`
+	ModelBilling                                             ModelBilling                                             `json:"ModelBilling"`
+	ModelCapabilities                                        ModelCapabilities                                        `json:"ModelCapabilities"`
+	ModelCapabilitiesLimits                                  ModelCapabilitiesLimits                                  `json:"ModelCapabilitiesLimits"`
+	ModelCapabilitiesLimitsVision                            ModelCapabilitiesLimitsVision                            `json:"ModelCapabilitiesLimitsVision"`
+	ModelCapabilitiesOverride                                ModelCapabilitiesOverride                                `json:"ModelCapabilitiesOverride"`
+	ModelCapabilitiesOverrideLimits                          ModelCapabilitiesOverrideLimits                          `json:"ModelCapabilitiesOverrideLimits"`
+	ModelCapabilitiesOverrideLimitsVision                    ModelCapabilitiesOverrideLimitsVision                    `json:"ModelCapabilitiesOverrideLimitsVision"`
+	ModelCapabilitiesOverrideSupports                        ModelCapabilitiesOverrideSupports                        `json:"ModelCapabilitiesOverrideSupports"`
+	ModelCapabilitiesSupports                                ModelCapabilitiesSupports                                `json:"ModelCapabilitiesSupports"`
+	ModelList                                                ModelList                                                `json:"ModelList"`
+	ModelPolicy                                              ModelPolicy                                              `json:"ModelPolicy"`
+	ModelsListRequest                                        ModelsListRequest                                        `json:"ModelsListRequest"`
+	ModelSwitchToRequest                                     ModelSwitchToRequest                                     `json:"ModelSwitchToRequest"`
+	ModelSwitchToResult                                      ModelSwitchToResult                                      `json:"ModelSwitchToResult"`
+	ModeSetRequest                                           ModeSetRequest                                           `json:"ModeSetRequest"`
+	ModeSetResult                                            ModeSetResult                                            `json:"ModeSetResult"`
+	NameGetResult                                            NameGetResult                                            `json:"NameGetResult"`
+	NameSetRequest                                           NameSetRequest                                           `json:"NameSetRequest"`
+	NameSetResult                                            NameSetResult                                            `json:"NameSetResult"`
+	PermissionDecision                                       PermissionDecision                                       `json:"PermissionDecision"`
+	PermissionDecisionApproveForLocation                     PermissionDecisionApproveForLocation                     `json:"PermissionDecisionApproveForLocation"`
+	PermissionDecisionApproveForLocationApproval             PermissionDecisionApproveForLocationApproval             `json:"PermissionDecisionApproveForLocationApproval"`
+	PermissionDecisionApproveForLocationApprovalCommands     PermissionDecisionApproveForLocationApprovalCommands     `json:"PermissionDecisionApproveForLocationApprovalCommands"`
+	PermissionDecisionApproveForLocationApprovalCustomTool   PermissionDecisionApproveForLocationApprovalCustomTool   `json:"PermissionDecisionApproveForLocationApprovalCustomTool"`
+	PermissionDecisionApproveForLocationApprovalMCP          PermissionDecisionApproveForLocationApprovalMCP          `json:"PermissionDecisionApproveForLocationApprovalMcp"`
+	PermissionDecisionApproveForLocationApprovalMCPSampling  PermissionDecisionApproveForLocationApprovalMCPSampling  `json:"PermissionDecisionApproveForLocationApprovalMcpSampling"`
+	PermissionDecisionApproveForLocationApprovalMemory       PermissionDecisionApproveForLocationApprovalMemory       `json:"PermissionDecisionApproveForLocationApprovalMemory"`
+	PermissionDecisionApproveForLocationApprovalRead         PermissionDecisionApproveForLocationApprovalRead         `json:"PermissionDecisionApproveForLocationApprovalRead"`
+	PermissionDecisionApproveForLocationApprovalWrite        PermissionDecisionApproveForLocationApprovalWrite        `json:"PermissionDecisionApproveForLocationApprovalWrite"`
+	PermissionDecisionApproveForSession                      PermissionDecisionApproveForSession                      `json:"PermissionDecisionApproveForSession"`
+	PermissionDecisionApproveForSessionApproval              PermissionDecisionApproveForSessionApproval              `json:"PermissionDecisionApproveForSessionApproval"`
+	PermissionDecisionApproveForSessionApprovalCommands      PermissionDecisionApproveForSessionApprovalCommands      `json:"PermissionDecisionApproveForSessionApprovalCommands"`
+	PermissionDecisionApproveForSessionApprovalCustomTool    PermissionDecisionApproveForSessionApprovalCustomTool    `json:"PermissionDecisionApproveForSessionApprovalCustomTool"`
+	PermissionDecisionApproveForSessionApprovalMCP           PermissionDecisionApproveForSessionApprovalMCP           `json:"PermissionDecisionApproveForSessionApprovalMcp"`
+	PermissionDecisionApproveForSessionApprovalMCPSampling   PermissionDecisionApproveForSessionApprovalMCPSampling   `json:"PermissionDecisionApproveForSessionApprovalMcpSampling"`
+	PermissionDecisionApproveForSessionApprovalMemory        PermissionDecisionApproveForSessionApprovalMemory        `json:"PermissionDecisionApproveForSessionApprovalMemory"`
+	PermissionDecisionApproveForSessionApprovalRead          PermissionDecisionApproveForSessionApprovalRead          `json:"PermissionDecisionApproveForSessionApprovalRead"`
+	PermissionDecisionApproveForSessionApprovalWrite         PermissionDecisionApproveForSessionApprovalWrite         `json:"PermissionDecisionApproveForSessionApprovalWrite"`
+	PermissionDecisionApproveOnce                            PermissionDecisionApproveOnce                            `json:"PermissionDecisionApproveOnce"`
+	PermissionDecisionApprovePermanently                     PermissionDecisionApprovePermanently                     `json:"PermissionDecisionApprovePermanently"`
+	PermissionDecisionReject                                 PermissionDecisionReject                                 `json:"PermissionDecisionReject"`
+	PermissionDecisionRequest                                PermissionDecisionRequest                                `json:"PermissionDecisionRequest"`
+	PermissionDecisionUserNotAvailable                       PermissionDecisionUserNotAvailable                       `json:"PermissionDecisionUserNotAvailable"`
+	PermissionRequestResult                                  PermissionRequestResult                                  `json:"PermissionRequestResult"`
+	PermissionsResetSessionApprovalsRequest                  PermissionsResetSessionApprovalsRequest                  `json:"PermissionsResetSessionApprovalsRequest"`
+	PermissionsResetSessionApprovalsResult                   PermissionsResetSessionApprovalsResult                   `json:"PermissionsResetSessionApprovalsResult"`
+	PermissionsSetApproveAllRequest                          PermissionsSetApproveAllRequest                          `json:"PermissionsSetApproveAllRequest"`
+	PermissionsSetApproveAllResult                           PermissionsSetApproveAllResult                           `json:"PermissionsSetApproveAllResult"`
+	PingRequest                                              PingRequest                                              `json:"PingRequest"`
+	PingResult                                               PingResult                                               `json:"PingResult"`
+	PlanDeleteResult                                         PlanDeleteResult                                         `json:"PlanDeleteResult"`
+	PlanReadResult                                           PlanReadResult                                           `json:"PlanReadResult"`
+	PlanUpdateRequest                                        PlanUpdateRequest                                        `json:"PlanUpdateRequest"`
+	PlanUpdateResult                                         PlanUpdateResult                                         `json:"PlanUpdateResult"`
+	Plugin                                                   PluginElement                                            `json:"Plugin"`
+	PluginList                                               PluginList                                               `json:"PluginList"`
+	ServerSkill                                              ServerSkill                                              `json:"ServerSkill"`
+	ServerSkillList                                          ServerSkillList                                          `json:"ServerSkillList"`
+	SessionAuthStatus                                        SessionAuthStatus                                        `json:"SessionAuthStatus"`
+	SessionFSAppendFileRequest                               SessionFSAppendFileRequest                               `json:"SessionFsAppendFileRequest"`
+	SessionFSError                                           SessionFSError                                           `json:"SessionFsError"`
+	SessionFSErrorCode                                       SessionFSErrorCode                                       `json:"SessionFsErrorCode"`
+	SessionFSExistsRequest                                   SessionFSExistsRequest                                   `json:"SessionFsExistsRequest"`
+	SessionFSExistsResult                                    SessionFSExistsResult                                    `json:"SessionFsExistsResult"`
+	SessionFSMkdirRequest                                    SessionFSMkdirRequest                                    `json:"SessionFsMkdirRequest"`
+	SessionFSReaddirRequest                                  SessionFSReaddirRequest                                  `json:"SessionFsReaddirRequest"`
+	SessionFSReaddirResult                                   SessionFSReaddirResult                                   `json:"SessionFsReaddirResult"`
+	SessionFSReaddirWithTypesEntry                           SessionFSReaddirWithTypesEntry                           `json:"SessionFsReaddirWithTypesEntry"`
+	SessionFSReaddirWithTypesEntryType                       SessionFSReaddirWithTypesEntryType                       `json:"SessionFsReaddirWithTypesEntryType"`
+	SessionFSReaddirWithTypesRequest                         SessionFSReaddirWithTypesRequest                         `json:"SessionFsReaddirWithTypesRequest"`
+	SessionFSReaddirWithTypesResult                          SessionFSReaddirWithTypesResult                          `json:"SessionFsReaddirWithTypesResult"`
+	SessionFSReadFileRequest                                 SessionFSReadFileRequest                                 `json:"SessionFsReadFileRequest"`
+	SessionFSReadFileResult                                  SessionFSReadFileResult                                  `json:"SessionFsReadFileResult"`
+	SessionFSRenameRequest                                   SessionFSRenameRequest                                   `json:"SessionFsRenameRequest"`
+	SessionFSRmRequest                                       SessionFSRmRequest                                       `json:"SessionFsRmRequest"`
+	SessionFSSetProviderConventions                          SessionFSSetProviderConventions                          `json:"SessionFsSetProviderConventions"`
+	SessionFSSetProviderRequest                              SessionFSSetProviderRequest                              `json:"SessionFsSetProviderRequest"`
+	SessionFSSetProviderResult                               SessionFSSetProviderResult                               `json:"SessionFsSetProviderResult"`
+	SessionFSStatRequest                                     SessionFSStatRequest                                     `json:"SessionFsStatRequest"`
+	SessionFSStatResult                                      SessionFSStatResult                                      `json:"SessionFsStatResult"`
+	SessionFSWriteFileRequest                                SessionFSWriteFileRequest                                `json:"SessionFsWriteFileRequest"`
+	SessionLogLevel                                          SessionLogLevel                                          `json:"SessionLogLevel"`
+	SessionMode                                              SessionMode                                              `json:"SessionMode"`
+	SessionsForkRequest                                      SessionsForkRequest                                      `json:"SessionsForkRequest"`
+	SessionsForkResult                                       SessionsForkResult                                       `json:"SessionsForkResult"`
+	ShellExecRequest                                         ShellExecRequest                                         `json:"ShellExecRequest"`
+	ShellExecResult                                          ShellExecResult                                          `json:"ShellExecResult"`
+	ShellKillRequest                                         ShellKillRequest                                         `json:"ShellKillRequest"`
+	ShellKillResult                                          ShellKillResult                                          `json:"ShellKillResult"`
+	ShellKillSignal                                          ShellKillSignal                                          `json:"ShellKillSignal"`
+	Skill                                                    Skill                                                    `json:"Skill"`
+	SkillList                                                SkillList                                                `json:"SkillList"`
+	SkillsConfigSetDisabledSkillsRequest                     SkillsConfigSetDisabledSkillsRequest                     `json:"SkillsConfigSetDisabledSkillsRequest"`
+	SkillsConfigSetDisabledSkillsResult                      SkillsConfigSetDisabledSkillsResult                      `json:"SkillsConfigSetDisabledSkillsResult"`
+	SkillsDisableRequest                                     SkillsDisableRequest                                     `json:"SkillsDisableRequest"`
+	SkillsDisableResult                                      SkillsDisableResult                                      `json:"SkillsDisableResult"`
+	SkillsDiscoverRequest                                    SkillsDiscoverRequest                                    `json:"SkillsDiscoverRequest"`
+	SkillsEnableRequest                                      SkillsEnableRequest                                      `json:"SkillsEnableRequest"`
+	SkillsEnableResult                                       SkillsEnableResult                                       `json:"SkillsEnableResult"`
+	SkillsReloadResult                                       SkillsReloadResult                                       `json:"SkillsReloadResult"`
+	TaskAgentInfo                                            TaskAgentInfo                                            `json:"TaskAgentInfo"`
+	TaskAgentInfoExecutionMode                               TaskInfoExecutionMode                                    `json:"TaskAgentInfoExecutionMode"`
+	TaskAgentInfoStatus                                      TaskInfoStatus                                           `json:"TaskAgentInfoStatus"`
+	TaskInfo                                                 TaskInfo                                                 `json:"TaskInfo"`
+	TaskList                                                 TaskList                                                 `json:"TaskList"`
+	TasksCancelRequest                                       TasksCancelRequest                                       `json:"TasksCancelRequest"`
+	TasksCancelResult                                        TasksCancelResult                                        `json:"TasksCancelResult"`
+	TaskShellInfo                                            TaskShellInfo                                            `json:"TaskShellInfo"`
+	TaskShellInfoAttachmentMode                              TaskShellInfoAttachmentMode                              `json:"TaskShellInfoAttachmentMode"`
+	TaskShellInfoExecutionMode                               TaskInfoExecutionMode                                    `json:"TaskShellInfoExecutionMode"`
+	TaskShellInfoStatus                                      TaskInfoStatus                                           `json:"TaskShellInfoStatus"`
+	TasksPromoteToBackgroundRequest                          TasksPromoteToBackgroundRequest                          `json:"TasksPromoteToBackgroundRequest"`
+	TasksPromoteToBackgroundResult                           TasksPromoteToBackgroundResult                           `json:"TasksPromoteToBackgroundResult"`
+	TasksRemoveRequest                                       TasksRemoveRequest                                       `json:"TasksRemoveRequest"`
+	TasksRemoveResult                                        TasksRemoveResult                                        `json:"TasksRemoveResult"`
+	TasksStartAgentRequest                                   TasksStartAgentRequest                                   `json:"TasksStartAgentRequest"`
+	TasksStartAgentResult                                    TasksStartAgentResult                                    `json:"TasksStartAgentResult"`
+	Tool                                                     Tool                                                     `json:"Tool"`
+	ToolList                                                 ToolList                                                 `json:"ToolList"`
+	ToolsListRequest                                         ToolsListRequest                                         `json:"ToolsListRequest"`
+	UIElicitationArrayAnyOfField                             UIElicitationArrayAnyOfField                             `json:"UIElicitationArrayAnyOfField"`
+	UIElicitationArrayAnyOfFieldItems                        UIElicitationArrayAnyOfFieldItems                        `json:"UIElicitationArrayAnyOfFieldItems"`
+	UIElicitationArrayAnyOfFieldItemsAnyOf                   UIElicitationArrayAnyOfFieldItemsAnyOf                   `json:"UIElicitationArrayAnyOfFieldItemsAnyOf"`
+	UIElicitationArrayEnumField                              UIElicitationArrayEnumField                              `json:"UIElicitationArrayEnumField"`
+	UIElicitationArrayEnumFieldItems                         UIElicitationArrayEnumFieldItems                         `json:"UIElicitationArrayEnumFieldItems"`
+	UIElicitationFieldValue                                  *UIElicitationFieldValue                                 `json:"UIElicitationFieldValue"`
+	UIElicitationRequest                                     UIElicitationRequest                                     `json:"UIElicitationRequest"`
+	UIElicitationResponse                                    UIElicitationResponse                                    `json:"UIElicitationResponse"`
+	UIElicitationResponseAction                              UIElicitationResponseAction                              `json:"UIElicitationResponseAction"`
+	UIElicitationResponseContent                             map[string]*UIElicitationFieldValue                      `json:"UIElicitationResponseContent"`
+	UIElicitationResult                                      UIElicitationResult                                      `json:"UIElicitationResult"`
+	UIElicitationSchema                                      UIElicitationSchema                                      `json:"UIElicitationSchema"`
+	UIElicitationSchemaProperty                              UIElicitationSchemaProperty                              `json:"UIElicitationSchemaProperty"`
+	UIElicitationSchemaPropertyBoolean                       UIElicitationSchemaPropertyBoolean                       `json:"UIElicitationSchemaPropertyBoolean"`
+	UIElicitationSchemaPropertyNumber                        UIElicitationSchemaPropertyNumber                        `json:"UIElicitationSchemaPropertyNumber"`
+	UIElicitationSchemaPropertyNumberType                    UIElicitationSchemaPropertyNumberTypeEnum                `json:"UIElicitationSchemaPropertyNumberType"`
+	UIElicitationSchemaPropertyString                        UIElicitationSchemaPropertyString                        `json:"UIElicitationSchemaPropertyString"`
+	UIElicitationSchemaPropertyStringFormat                  UIElicitationSchemaPropertyStringFormat                  `json:"UIElicitationSchemaPropertyStringFormat"`
+	UIElicitationStringEnumField                             UIElicitationStringEnumField                             `json:"UIElicitationStringEnumField"`
+	UIElicitationStringOneOfField                            UIElicitationStringOneOfField                            `json:"UIElicitationStringOneOfField"`
+	UIElicitationStringOneOfFieldOneOf                       UIElicitationStringOneOfFieldOneOf                       `json:"UIElicitationStringOneOfFieldOneOf"`
+	UIHandlePendingElicitationRequest                        UIHandlePendingElicitationRequest                        `json:"UIHandlePendingElicitationRequest"`
+	UsageGetMetricsResult                                    UsageGetMetricsResult                                    `json:"UsageGetMetricsResult"`
+	UsageMetricsCodeChanges                                  UsageMetricsCodeChanges                                  `json:"UsageMetricsCodeChanges"`
+	UsageMetricsModelMetric                                  UsageMetricsModelMetric                                  `json:"UsageMetricsModelMetric"`
+	UsageMetricsModelMetricRequests                          UsageMetricsModelMetricRequests                          `json:"UsageMetricsModelMetricRequests"`
+	UsageMetricsModelMetricTokenDetail                       UsageMetricsModelMetricTokenDetail                       `json:"UsageMetricsModelMetricTokenDetail"`
+	UsageMetricsModelMetricUsage                             UsageMetricsModelMetricUsage                             `json:"UsageMetricsModelMetricUsage"`
+	UsageMetricsTokenDetail                                  UsageMetricsTokenDetail                                  `json:"UsageMetricsTokenDetail"`
+	WorkspacesCreateFileRequest                              WorkspacesCreateFileRequest                              `json:"WorkspacesCreateFileRequest"`
+	WorkspacesCreateFileResult                               WorkspacesCreateFileResult                               `json:"WorkspacesCreateFileResult"`
+	WorkspacesGetWorkspaceResult                             WorkspacesGetWorkspaceResult                             `json:"WorkspacesGetWorkspaceResult"`
+	WorkspacesListFilesResult                                WorkspacesListFilesResult                                `json:"WorkspacesListFilesResult"`
+	WorkspacesReadFileRequest                                WorkspacesReadFileRequest                                `json:"WorkspacesReadFileRequest"`
+	WorkspacesReadFileResult                                 WorkspacesReadFileResult                                 `json:"WorkspacesReadFileResult"`
 }
 
 type AccountGetQuotaRequest struct {
@@ -347,6 +362,24 @@ type DiscoveredMCPServer struct {
 	Type *DiscoveredMCPServerType `json:"type,omitempty"`
 }
 
+type EmbeddedBlobResourceContents struct {
+	// Base64-encoded binary content of the resource
+	Blob string `json:"blob"`
+	// MIME type of the blob content
+	MIMEType *string `json:"mimeType,omitempty"`
+	// URI identifying the resource
+	URI string `json:"uri"`
+}
+
+type EmbeddedTextResourceContents struct {
+	// MIME type of the text content
+	MIMEType *string `json:"mimeType,omitempty"`
+	// Text content of the resource
+	Text string `json:"text"`
+	// URI identifying the resource
+	URI string `json:"uri"`
+}
+
 type Extension struct {
 	// Source-qualified ID (e.g., 'project:my-ext', 'user:auth-helper')
 	ID string `json:"id"`
@@ -390,6 +423,168 @@ type ExtensionsEnableResult struct {
 type ExtensionsReloadResult struct {
 }
 
+// Expanded external tool result payload
+type ExternalToolTextResultForLlm struct {
+	// Structured content blocks from the tool
+	Contents []ExternalToolTextResultForLlmContent `json:"contents,omitempty"`
+	// Optional error message for failed executions
+	Error *string `json:"error,omitempty"`
+	// Execution outcome classification. Optional for back-compat; normalized to 'success' (or
+	// 'failure' when error is present) when missing or unrecognized.
+	ResultType *string `json:"resultType,omitempty"`
+	// Detailed log content for timeline display
+	SessionLog *string `json:"sessionLog,omitempty"`
+	// Text result returned to the model
+	TextResultForLlm string `json:"textResultForLlm"`
+	// Optional tool-specific telemetry
+	ToolTelemetry map[string]any `json:"toolTelemetry,omitempty"`
+}
+
+// A content block within a tool result, which may be text, terminal output, image, audio,
+// or a resource
+//
+// # Plain text content block
+//
+// Terminal/shell output content block with optional exit code and working directory
+//
+// # Image content block with base64-encoded data
+//
+// # Audio content block with base64-encoded data
+//
+// # Resource link content block referencing an external resource
+//
+// Embedded resource content block with inline text or binary data
+type ExternalToolTextResultForLlmContent struct {
+	// The text content
+	//
+	// Terminal/shell output text
+	Text *string `json:"text,omitempty"`
+	// Content block type discriminator
+	Type ExternalToolTextResultForLlmContentType `json:"type"`
+	// Working directory where the command was executed
+	Cwd *string `json:"cwd,omitempty"`
+	// Process exit code, if the command has completed
+	ExitCode *float64 `json:"exitCode,omitempty"`
+	// Base64-encoded image data
+	//
+	// Base64-encoded audio data
+	Data *string `json:"data,omitempty"`
+	// MIME type of the image (e.g., image/png, image/jpeg)
+	//
+	// MIME type of the audio (e.g., audio/wav, audio/mpeg)
+	//
+	// MIME type of the resource content
+	MIMEType *string `json:"mimeType,omitempty"`
+	// Human-readable description of the resource
+	Description *string `json:"description,omitempty"`
+	// Icons associated with this resource
+	Icons []ExternalToolTextResultForLlmContentResourceLinkIcon `json:"icons,omitempty"`
+	// Resource name identifier
+	Name *string `json:"name,omitempty"`
+	// Size of the resource in bytes
+	Size *float64 `json:"size,omitempty"`
+	// Human-readable display title for the resource
+	Title *string `json:"title,omitempty"`
+	// URI identifying the resource
+	URI *string `json:"uri,omitempty"`
+	// The embedded resource contents, either text or base64-encoded binary
+	Resource *ExternalToolTextResultForLlmContentResourceDetails `json:"resource,omitempty"`
+}
+
+// Icon image for a resource
+type ExternalToolTextResultForLlmContentResourceLinkIcon struct {
+	// MIME type of the icon image
+	MIMEType *string `json:"mimeType,omitempty"`
+	// Available icon sizes (e.g., ['16x16', '32x32'])
+	Sizes []string `json:"sizes,omitempty"`
+	// URL or path to the icon image
+	Src string `json:"src"`
+	// Theme variant this icon is intended for
+	Theme *ExternalToolTextResultForLlmContentResourceLinkIconTheme `json:"theme,omitempty"`
+}
+
+// The embedded resource contents, either text or base64-encoded binary
+type ExternalToolTextResultForLlmContentResourceDetails struct {
+	// MIME type of the text content
+	//
+	// MIME type of the blob content
+	MIMEType *string `json:"mimeType,omitempty"`
+	// Text content of the resource
+	Text *string `json:"text,omitempty"`
+	// URI identifying the resource
+	URI string `json:"uri"`
+	// Base64-encoded binary content of the resource
+	Blob *string `json:"blob,omitempty"`
+}
+
+// Audio content block with base64-encoded data
+type ExternalToolTextResultForLlmContentAudio struct {
+	// Base64-encoded audio data
+	Data string `json:"data"`
+	// MIME type of the audio (e.g., audio/wav, audio/mpeg)
+	MIMEType string `json:"mimeType"`
+	// Content block type discriminator
+	Type ExternalToolTextResultForLlmContentAudioType `json:"type"`
+}
+
+// Image content block with base64-encoded data
+type ExternalToolTextResultForLlmContentImage struct {
+	// Base64-encoded image data
+	Data string `json:"data"`
+	// MIME type of the image (e.g., image/png, image/jpeg)
+	MIMEType string `json:"mimeType"`
+	// Content block type discriminator
+	Type ExternalToolTextResultForLlmContentImageType `json:"type"`
+}
+
+// Embedded resource content block with inline text or binary data
+type ExternalToolTextResultForLlmContentResource struct {
+	// The embedded resource contents, either text or base64-encoded binary
+	Resource ExternalToolTextResultForLlmContentResourceDetails `json:"resource"`
+	// Content block type discriminator
+	Type ExternalToolTextResultForLlmContentResourceType `json:"type"`
+}
+
+// Resource link content block referencing an external resource
+type ExternalToolTextResultForLlmContentResourceLink struct {
+	// Human-readable description of the resource
+	Description *string `json:"description,omitempty"`
+	// Icons associated with this resource
+	Icons []ExternalToolTextResultForLlmContentResourceLinkIcon `json:"icons,omitempty"`
+	// MIME type of the resource content
+	MIMEType *string `json:"mimeType,omitempty"`
+	// Resource name identifier
+	Name string `json:"name"`
+	// Size of the resource in bytes
+	Size *float64 `json:"size,omitempty"`
+	// Human-readable display title for the resource
+	Title *string `json:"title,omitempty"`
+	// Content block type discriminator
+	Type ExternalToolTextResultForLlmContentResourceLinkType `json:"type"`
+	// URI identifying the resource
+	URI string `json:"uri"`
+}
+
+// Terminal/shell output content block with optional exit code and working directory
+type ExternalToolTextResultForLlmContentTerminal struct {
+	// Working directory where the command was executed
+	Cwd *string `json:"cwd,omitempty"`
+	// Process exit code, if the command has completed
+	ExitCode *float64 `json:"exitCode,omitempty"`
+	// Terminal/shell output text
+	Text string `json:"text"`
+	// Content block type discriminator
+	Type ExternalToolTextResultForLlmContentTerminalType `json:"type"`
+}
+
+// Plain text content block
+type ExternalToolTextResultForLlmContentText struct {
+	// The text content
+	Text string `json:"text"`
+	// Content block type discriminator
+	Type ExternalToolTextResultForLlmContentTextType `json:"type"`
+}
+
 // Experimental: FleetStartRequest is part of an experimental API and may change or be removed.
 type FleetStartRequest struct {
 	// Optional user prompt to combine with fleet instructions
@@ -402,7 +597,16 @@ type FleetStartResult struct {
 	Started bool `json:"started"`
 }
 
-type HandleToolCallResult struct {
+type HandlePendingToolCallRequest struct {
+	// Error message if the tool call failed
+	Error *string `json:"error,omitempty"`
+	// Request ID of the pending tool call
+	RequestID string `json:"requestId"`
+	// Tool call result (string or expanded result object)
+	Result *ExternalToolResult `json:"result"`
+}
+
+type HandlePendingToolCallResult struct {
 	// Whether the tool call result was handled successfully
 	Success bool `json:"success"`
 }
@@ -816,6 +1020,8 @@ type PermissionDecision struct {
 	//
 	// Approved and persisted for this project location
 	//
+	// Approved and persisted across sessions
+	//
 	// Denied by the user during an interactive prompt
 	//
 	// Denied because user confirmation was unavailable
@@ -824,6 +1030,10 @@ type PermissionDecision struct {
 	//
 	// The approval to persist for this location
 	Approval *PermissionDecisionApproveForLocationApproval `json:"approval,omitempty"`
+	// The URL domain to approve for this session
+	//
+	// The URL domain to approve permanently
+	Domain *string `json:"domain,omitempty"`
 	// The location key (git root or cwd) to persist the approval to
 	LocationKey *string `json:"locationKey,omitempty"`
 	// Optional feedback from the user explaining the denial
@@ -882,7 +1092,9 @@ type PermissionDecisionApproveForLocationApprovalWrite struct {
 
 type PermissionDecisionApproveForSession struct {
 	// The approval to add as a session-scoped rule
-	Approval PermissionDecisionApproveForSessionApproval `json:"approval"`
+	Approval *PermissionDecisionApproveForSessionApproval `json:"approval,omitempty"`
+	// The URL domain to approve for this session
+	Domain *string `json:"domain,omitempty"`
 	// Approved and remembered for the rest of the session
 	Kind PermissionDecisionApproveForSessionKind `json:"kind"`
 }
@@ -931,6 +1143,13 @@ type PermissionDecisionApproveForSessionApprovalWrite struct {
 type PermissionDecisionApproveOnce struct {
 	// The permission request was approved for this one instance
 	Kind PermissionDecisionApproveOnceKind `json:"kind"`
+}
+
+type PermissionDecisionApprovePermanently struct {
+	// The URL domain to approve permanently
+	Domain string `json:"domain"`
+	// Approved and persisted across sessions
+	Kind PermissionDecisionApprovePermanentlyKind `json:"kind"`
 }
 
 type PermissionDecisionReject struct {
@@ -1521,29 +1740,9 @@ type Tool struct {
 	Parameters map[string]any `json:"parameters,omitempty"`
 }
 
-type ToolCallResult struct {
-	// Error message if the tool call failed
-	Error *string `json:"error,omitempty"`
-	// Type of the tool result
-	ResultType *string `json:"resultType,omitempty"`
-	// Text result to send back to the LLM
-	TextResultForLlm string `json:"textResultForLlm"`
-	// Telemetry data from tool execution
-	ToolTelemetry map[string]any `json:"toolTelemetry,omitempty"`
-}
-
 type ToolList struct {
 	// List of available built-in tools with metadata
 	Tools []Tool `json:"tools"`
-}
-
-type ToolsHandlePendingToolCallRequest struct {
-	// Error message if the tool call failed
-	Error *string `json:"error,omitempty"`
-	// Request ID of the pending tool call
-	RequestID string `json:"requestId"`
-	// Tool call result (string or expanded result object)
-	Result *ToolsHandlePendingToolCall `json:"result"`
 }
 
 type ToolsListRequest struct {
@@ -1710,8 +1909,12 @@ type UsageGetMetricsResult struct {
 	ModelMetrics map[string]UsageMetricsModelMetric `json:"modelMetrics"`
 	// Session start timestamp (epoch milliseconds)
 	SessionStartTime int64 `json:"sessionStartTime"`
+	// Session-wide per-token-type accumulated token counts
+	TokenDetails map[string]UsageMetricsTokenDetail `json:"tokenDetails,omitempty"`
 	// Total time spent in model API calls (milliseconds)
 	TotalAPIDurationMS float64 `json:"totalApiDurationMs"`
+	// Session-wide accumulated nano-AI units cost
+	TotalNanoAiu *int64 `json:"totalNanoAiu,omitempty"`
 	// Total user-initiated premium request cost across all models (may be fractional due to
 	// multipliers)
 	TotalPremiumRequestCost float64 `json:"totalPremiumRequestCost"`
@@ -1732,6 +1935,10 @@ type UsageMetricsCodeChanges struct {
 type UsageMetricsModelMetric struct {
 	// Request count and cost metrics for this model
 	Requests UsageMetricsModelMetricRequests `json:"requests"`
+	// Token count details per type
+	TokenDetails map[string]UsageMetricsModelMetricTokenDetail `json:"tokenDetails,omitempty"`
+	// Accumulated nano-AI units cost for this model
+	TotalNanoAiu *int64 `json:"totalNanoAiu,omitempty"`
 	// Token usage metrics for this model
 	Usage UsageMetricsModelMetricUsage `json:"usage"`
 }
@@ -1742,6 +1949,11 @@ type UsageMetricsModelMetricRequests struct {
 	Cost float64 `json:"cost"`
 	// Number of API requests made with this model
 	Count int64 `json:"count"`
+}
+
+type UsageMetricsModelMetricTokenDetail struct {
+	// Accumulated token count for this token type
+	TokenCount int64 `json:"tokenCount"`
 }
 
 // Token usage metrics for this model
@@ -1756,6 +1968,11 @@ type UsageMetricsModelMetricUsage struct {
 	OutputTokens int64 `json:"outputTokens"`
 	// Total output tokens used for reasoning
 	ReasoningTokens *int64 `json:"reasoningTokens,omitempty"`
+}
+
+type UsageMetricsTokenDetail struct {
+	// Accumulated token count for this token type
+	TokenCount int64 `json:"tokenCount"`
 }
 
 type WorkspacesCreateFileRequest struct {
@@ -1862,6 +2079,61 @@ const (
 	ExtensionStatusStarting ExtensionStatus = "starting"
 )
 
+// Theme variant this icon is intended for
+type ExternalToolTextResultForLlmContentResourceLinkIconTheme string
+
+const (
+	ExternalToolTextResultForLlmContentResourceLinkIconThemeDark  ExternalToolTextResultForLlmContentResourceLinkIconTheme = "dark"
+	ExternalToolTextResultForLlmContentResourceLinkIconThemeLight ExternalToolTextResultForLlmContentResourceLinkIconTheme = "light"
+)
+
+type ExternalToolTextResultForLlmContentType string
+
+const (
+	ExternalToolTextResultForLlmContentTypeAudio        ExternalToolTextResultForLlmContentType = "audio"
+	ExternalToolTextResultForLlmContentTypeImage        ExternalToolTextResultForLlmContentType = "image"
+	ExternalToolTextResultForLlmContentTypeResource     ExternalToolTextResultForLlmContentType = "resource"
+	ExternalToolTextResultForLlmContentTypeResourceLink ExternalToolTextResultForLlmContentType = "resource_link"
+	ExternalToolTextResultForLlmContentTypeTerminal     ExternalToolTextResultForLlmContentType = "terminal"
+	ExternalToolTextResultForLlmContentTypeText         ExternalToolTextResultForLlmContentType = "text"
+)
+
+type ExternalToolTextResultForLlmContentAudioType string
+
+const (
+	ExternalToolTextResultForLlmContentAudioTypeAudio ExternalToolTextResultForLlmContentAudioType = "audio"
+)
+
+type ExternalToolTextResultForLlmContentImageType string
+
+const (
+	ExternalToolTextResultForLlmContentImageTypeImage ExternalToolTextResultForLlmContentImageType = "image"
+)
+
+type ExternalToolTextResultForLlmContentResourceType string
+
+const (
+	ExternalToolTextResultForLlmContentResourceTypeResource ExternalToolTextResultForLlmContentResourceType = "resource"
+)
+
+type ExternalToolTextResultForLlmContentResourceLinkType string
+
+const (
+	ExternalToolTextResultForLlmContentResourceLinkTypeResourceLink ExternalToolTextResultForLlmContentResourceLinkType = "resource_link"
+)
+
+type ExternalToolTextResultForLlmContentTerminalType string
+
+const (
+	ExternalToolTextResultForLlmContentTerminalTypeTerminal ExternalToolTextResultForLlmContentTerminalType = "terminal"
+)
+
+type ExternalToolTextResultForLlmContentTextType string
+
+const (
+	ExternalToolTextResultForLlmContentTextTypeText ExternalToolTextResultForLlmContentTextType = "text"
+)
+
 type FilterMappingString string
 
 const (
@@ -1965,6 +2237,7 @@ const (
 	PermissionDecisionKindApproveForLocation PermissionDecisionKind = "approve-for-location"
 	PermissionDecisionKindApproveForSession  PermissionDecisionKind = "approve-for-session"
 	PermissionDecisionKindApproveOnce        PermissionDecisionKind = "approve-once"
+	PermissionDecisionKindApprovePermanently PermissionDecisionKind = "approve-permanently"
 	PermissionDecisionKindReject             PermissionDecisionKind = "reject"
 	PermissionDecisionKindUserNotAvailable   PermissionDecisionKind = "user-not-available"
 )
@@ -2027,6 +2300,12 @@ type PermissionDecisionApproveOnceKind string
 
 const (
 	PermissionDecisionApproveOnceKindApproveOnce PermissionDecisionApproveOnceKind = "approve-once"
+)
+
+type PermissionDecisionApprovePermanentlyKind string
+
+const (
+	PermissionDecisionApprovePermanentlyKindApprovePermanently PermissionDecisionApprovePermanentlyKind = "approve-permanently"
 )
 
 type PermissionDecisionRejectKind string
@@ -2197,15 +2476,15 @@ const (
 	SessionSyncLevelUser        SessionSyncLevel = "user"
 )
 
+// Tool call result (string or expanded result object)
+type ExternalToolResult struct {
+	ExternalToolTextResultForLlm *ExternalToolTextResultForLlm
+	String                       *string
+}
+
 type FilterMapping struct {
 	Enum    *FilterMappingString
 	EnumMap map[string]FilterMappingString
-}
-
-// Tool call result (string or expanded result object)
-type ToolsHandlePendingToolCall struct {
-	String         *string
-	ToolCallResult *ToolCallResult
 }
 
 type UIElicitationFieldValue struct {
@@ -3105,7 +3384,7 @@ func (a *ExtensionsApi) Reload(ctx context.Context) (*ExtensionsReloadResult, er
 
 type ToolsApi sessionApi
 
-func (a *ToolsApi) HandlePendingToolCall(ctx context.Context, params *ToolsHandlePendingToolCallRequest) (*HandleToolCallResult, error) {
+func (a *ToolsApi) HandlePendingToolCall(ctx context.Context, params *HandlePendingToolCallRequest) (*HandlePendingToolCallResult, error) {
 	req := map[string]any{"sessionId": a.sessionID}
 	if params != nil {
 		req["requestId"] = params.RequestID
@@ -3120,7 +3399,7 @@ func (a *ToolsApi) HandlePendingToolCall(ctx context.Context, params *ToolsHandl
 	if err != nil {
 		return nil, err
 	}
-	var result HandleToolCallResult
+	var result HandlePendingToolCallResult
 	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}

--- a/go/rpc/generated_rpc.go
+++ b/go/rpc/generated_rpc.go
@@ -93,6 +93,7 @@ type RPCTypes struct {
 	MCPServer                                                MCPServer                                                `json:"McpServer"`
 	MCPServerConfig                                          MCPServerConfig                                          `json:"McpServerConfig"`
 	MCPServerConfigHTTP                                      MCPServerConfigHTTP                                      `json:"McpServerConfigHttp"`
+	MCPServerConfigHTTPOauthGrantType                        MCPServerConfigHTTPOauthGrantType                        `json:"McpServerConfigHttpOauthGrantType"`
 	MCPServerConfigHTTPType                                  MCPServerConfigHTTPType                                  `json:"McpServerConfigHttpType"`
 	MCPServerConfigLocal                                     MCPServerConfigLocal                                     `json:"McpServerConfigLocal"`
 	MCPServerConfigLocalType                                 MCPServerConfigLocalType                                 `json:"McpServerConfigLocalType"`
@@ -712,11 +713,12 @@ type MCPServerConfig struct {
 	// Tools to include. Defaults to all tools if not specified.
 	Tools []string `json:"tools,omitempty"`
 	// Remote transport type. Defaults to "http" when omitted.
-	Type              *MCPServerConfigType `json:"type,omitempty"`
-	Headers           map[string]string    `json:"headers,omitempty"`
-	OauthClientID     *string              `json:"oauthClientId,omitempty"`
-	OauthPublicClient *bool                `json:"oauthPublicClient,omitempty"`
-	URL               *string              `json:"url,omitempty"`
+	Type              *MCPServerConfigType               `json:"type,omitempty"`
+	Headers           map[string]string                  `json:"headers,omitempty"`
+	OauthClientID     *string                            `json:"oauthClientId,omitempty"`
+	OauthGrantType    *MCPServerConfigHTTPOauthGrantType `json:"oauthGrantType,omitempty"`
+	OauthPublicClient *bool                              `json:"oauthPublicClient,omitempty"`
+	URL               *string                            `json:"url,omitempty"`
 }
 
 type MCPConfigAddResult struct {
@@ -833,11 +835,12 @@ type MCPServer struct {
 }
 
 type MCPServerConfigHTTP struct {
-	FilterMapping     *FilterMapping    `json:"filterMapping"`
-	Headers           map[string]string `json:"headers,omitempty"`
-	IsDefaultServer   *bool             `json:"isDefaultServer,omitempty"`
-	OauthClientID     *string           `json:"oauthClientId,omitempty"`
-	OauthPublicClient *bool             `json:"oauthPublicClient,omitempty"`
+	FilterMapping     *FilterMapping                     `json:"filterMapping"`
+	Headers           map[string]string                  `json:"headers,omitempty"`
+	IsDefaultServer   *bool                              `json:"isDefaultServer,omitempty"`
+	OauthClientID     *string                            `json:"oauthClientId,omitempty"`
+	OauthGrantType    *MCPServerConfigHTTPOauthGrantType `json:"oauthGrantType,omitempty"`
+	OauthPublicClient *bool                              `json:"oauthPublicClient,omitempty"`
 	// Timeout in milliseconds for tool calls to this server.
 	Timeout *int64 `json:"timeout,omitempty"`
 	// Tools to include. Defaults to all tools if not specified.
@@ -2171,6 +2174,13 @@ const (
 	SessionLogLevelError   SessionLogLevel = "error"
 	SessionLogLevelInfo    SessionLogLevel = "info"
 	SessionLogLevelWarning SessionLogLevel = "warning"
+)
+
+type MCPServerConfigHTTPOauthGrantType string
+
+const (
+	MCPServerConfigHTTPOauthGrantTypeAuthorizationCode MCPServerConfigHTTPOauthGrantType = "authorization_code"
+	MCPServerConfigHTTPOauthGrantTypeClientCredentials MCPServerConfigHTTPOauthGrantType = "client_credentials"
 )
 
 // Remote transport type. Defaults to "http" when omitted.

--- a/go/rpc/result_union.go
+++ b/go/rpc/result_union.go
@@ -2,33 +2,33 @@ package rpc
 
 import "encoding/json"
 
-// MarshalJSON serializes ToolsHandlePendingToolCall as the appropriate JSON variant:
-// a plain string when String is set, or the ToolCallResult object otherwise.
+// MarshalJSON serializes ExternalToolResult as the appropriate JSON variant:
+// a plain string when String is set, or the ExternalToolTextResultForLlm object otherwise.
 // The generated struct has no custom marshaler, so without this the Go
-// struct fields would serialize as {"ToolCallResult":...,"String":...}
+// struct fields would serialize as {"ExternalToolTextResultForLlm":...,"String":...}
 // instead of the union the server expects.
-func (r ToolsHandlePendingToolCall) MarshalJSON() ([]byte, error) {
+func (r ExternalToolResult) MarshalJSON() ([]byte, error) {
 	if r.String != nil {
 		return json.Marshal(*r.String)
 	}
-	if r.ToolCallResult != nil {
-		return json.Marshal(*r.ToolCallResult)
+	if r.ExternalToolTextResultForLlm != nil {
+		return json.Marshal(*r.ExternalToolTextResultForLlm)
 	}
 	return []byte("null"), nil
 }
 
-// UnmarshalJSON deserializes a JSON value into the appropriate ToolsHandlePendingToolCall variant.
-func (r *ToolsHandlePendingToolCall) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON deserializes a JSON value into the appropriate ExternalToolResult variant.
+func (r *ExternalToolResult) UnmarshalJSON(data []byte) error {
 	// Try string first
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
 		r.String = &s
 		return nil
 	}
-	// Try ToolCallResult object
-	var rr ToolCallResult
+	// Try ExternalToolTextResultForLlm object
+	var rr ExternalToolTextResultForLlm
 	if err := json.Unmarshal(data, &rr); err == nil {
-		r.ToolCallResult = &rr
+		r.ExternalToolTextResultForLlm = &rr
 		return nil
 	}
 	return nil

--- a/go/session.go
+++ b/go/session.go
@@ -966,7 +966,7 @@ func (s *Session) executeToolAndRespond(requestID, toolName, toolCallID string, 
 	defer func() {
 		if r := recover(); r != nil {
 			errMsg := fmt.Sprintf("tool panic: %v", r)
-			s.RPC.Tools.HandlePendingToolCall(ctx, &rpc.ToolsHandlePendingToolCallRequest{
+			s.RPC.Tools.HandlePendingToolCall(ctx, &rpc.HandlePendingToolCallRequest{
 				RequestID: requestID,
 				Error:     &errMsg,
 			})
@@ -984,7 +984,7 @@ func (s *Session) executeToolAndRespond(requestID, toolName, toolCallID string, 
 	result, err := handler(invocation)
 	if err != nil {
 		errMsg := err.Error()
-		s.RPC.Tools.HandlePendingToolCall(ctx, &rpc.ToolsHandlePendingToolCallRequest{
+		s.RPC.Tools.HandlePendingToolCall(ctx, &rpc.HandlePendingToolCallRequest{
 			RequestID: requestID,
 			Error:     &errMsg,
 		})
@@ -1006,17 +1006,17 @@ func (s *Session) executeToolAndRespond(requestID, toolName, toolCallID string, 
 		}
 	}
 
-	rpcResult := rpc.ToolsHandlePendingToolCall{
-		ToolCallResult: &rpc.ToolCallResult{
+	rpcResult := rpc.ExternalToolResult{
+		ExternalToolTextResultForLlm: &rpc.ExternalToolTextResultForLlm{
 			TextResultForLlm: textResultForLLM,
 			ToolTelemetry:    result.ToolTelemetry,
 			ResultType:       &effectiveResultType,
 		},
 	}
 	if result.Error != "" {
-		rpcResult.ToolCallResult.Error = &result.Error
+		rpcResult.ExternalToolTextResultForLlm.Error = &result.Error
 	}
-	s.RPC.Tools.HandlePendingToolCall(ctx, &rpc.ToolsHandlePendingToolCallRequest{
+	s.RPC.Tools.HandlePendingToolCall(ctx, &rpc.HandlePendingToolCallRequest{
 		RequestID: requestID,
 		Result:    &rpcResult,
 	})

--- a/go/types.go
+++ b/go/types.go
@@ -804,6 +804,15 @@ type ResumeSessionConfig struct {
 	// DisableResume, when true, skips emitting the session.resume event.
 	// Useful for reconnecting to a session without triggering resume-related side effects.
 	DisableResume bool
+	// ContinuePendingWork, when true, instructs the runtime to continue any tool calls
+	// or permission prompts that were still pending when the session was last suspended.
+	// When false (the default), the runtime treats pending work as interrupted on resume.
+	//
+	// For permission requests, the runtime re-emits permission.requested so the
+	// registered OnPermissionRequest handler can re-prompt; for external tool calls,
+	// the consumer is expected to supply the result via the corresponding low-level
+	// RPC method.
+	ContinuePendingWork bool
 	// OnEvent is an optional event handler registered before the session.resume RPC
 	// is issued, ensuring early events are delivered. See SessionConfig.OnEvent.
 	OnEvent SessionEventHandler
@@ -1050,6 +1059,7 @@ type resumeSessionRequest struct {
 	ConfigDir                      string                         `json:"configDir,omitempty"`
 	EnableConfigDiscovery          *bool                          `json:"enableConfigDiscovery,omitempty"`
 	DisableResume                  *bool                          `json:"disableResume,omitempty"`
+	ContinuePendingWork            *bool                          `json:"continuePendingWork,omitempty"`
 	Streaming                      *bool                          `json:"streaming,omitempty"`
 	IncludeSubAgentStreamingEvents *bool                          `json:"includeSubAgentStreamingEvents,omitempty"`
 	MCPServers                     map[string]MCPServerConfig     `json:"mcpServers,omitempty"`

--- a/haskell/src/Copilot/Client.hs
+++ b/haskell/src/Copilot/Client.hs
@@ -24,6 +24,8 @@ module Copilot.Client
   , deleteSession
   , listSessions
   , getLastSessionId
+  , getForegroundSessionId
+  , setForegroundSessionId
 
     -- * Queries
   , ping
@@ -433,6 +435,33 @@ getLastSessionId client = do
   case result of
     Left _ -> pure Nothing
     Right val -> pure $ parseMaybe (withObject "" $ \o -> o .: "sessionId") val
+
+-- | Get the foreground session ID.
+getForegroundSessionId :: CopilotClient -> IO (Maybe Text)
+getForegroundSessionId client = do
+  rpc <- ensureConnected client
+  result <- sendRequest rpc "session.getForeground" (object [])
+  case result of
+    Left _ -> pure Nothing
+    Right val -> pure $ parseMaybe (withObject "" $ \o -> o .: "sessionId") val
+
+-- | Set the foreground session ID.
+setForegroundSessionId :: CopilotClient -> Text -> IO ()
+setForegroundSessionId client sessionId = do
+  rpc <- ensureConnected client
+  result <- sendRequest rpc "session.setForeground" (object [ "sessionId" .= sessionId ])
+  case result of
+    Left err -> throwIO $ ServerError (jreMessage err)
+    Right val -> do
+      let mSuccess = parseMaybe (withObject "" $ \o -> o .: "success") val :: Maybe Bool
+          mError = parseMaybe (withObject "" $ \o -> o .:? "error") val :: Maybe (Maybe Text)
+      case mSuccess of
+        Just True -> pure ()
+        _ -> do
+          let errMsg = case mError of
+                Just (Just e) -> e
+                _             -> "Unknown error"
+          throwIO $ ServerError $ "Failed to set foreground session: " <> errMsg
 
 -- ============================================================================
 -- Queries

--- a/julia/src/client.jl
+++ b/julia/src/client.jl
@@ -224,6 +224,35 @@ function list_sessions(client::CopilotClient)
     return sessions
 end
 
+"""
+    get_foreground_session_id(client) -> String
+
+Return the session ID of the current foreground session.
+"""
+function get_foreground_session_id(client::CopilotClient)
+    _ensure_started!(client)
+    result = send_request(client.rpc, "session.getForeground", Dict{String,Any}(); timeout=10)
+    if result isa Dict
+        return get(result, "sessionId", "")
+    end
+    return ""
+end
+
+"""
+    set_foreground_session_id(client, session_id)
+
+Set the foreground session to the given session ID.
+"""
+function set_foreground_session_id(client::CopilotClient, session_id::AbstractString)
+    _ensure_started!(client)
+    result = send_request(client.rpc, "session.setForeground",
+        Dict{String,Any}("sessionId" => session_id); timeout=10)
+    if result isa Dict && get(result, "success", false) != true
+        error_msg = get(result, "error", "Unknown")
+        throw(ErrorException("Failed to set foreground session: $error_msg"))
+    end
+end
+
 # -- Internal helpers -------------------------------------------------------------
 
 function _ensure_started!(client::CopilotClient)

--- a/matlab/+copilot/CopilotClient.m
+++ b/matlab/+copilot/CopilotClient.m
@@ -217,8 +217,16 @@ classdef CopilotClient < handle
                 sessionId (1,:) char
             end
             obj.assertRunning();
-            obj.RpcClient.notify('session/setForeground', ...
-                struct('sessionId', sessionId));
+            result = obj.RpcClient.request('session.setForeground', ...
+                struct('sessionId', sessionId), 10);
+            if isfield(result, 'success') && ~result.success
+                errMsg = 'Unknown error';
+                if isfield(result, 'error')
+                    errMsg = result.error;
+                end
+                error('copilot:setForegroundFailed', ...
+                    'Failed to set foreground session: %s', errMsg);
+            end
         end
 
         function sessions = listSessions(obj, filter)
@@ -291,7 +299,7 @@ classdef CopilotClient < handle
         function sid = getForegroundSessionId(obj)
             %getForegroundSessionId  Return the foreground session identifier.
             obj.assertRunning();
-            result = obj.RpcClient.request('session/getForeground', struct(), 10);
+            result = obj.RpcClient.request('session.getForeground', struct(), 10);
             sid = '';
             if isfield(result, 'sessionId')
                 sid = result.sessionId;

--- a/nim/src/copilot_sdk/client.nim
+++ b/nim/src/copilot_sdk/client.nim
@@ -374,3 +374,17 @@ proc getSession*(client: CopilotClient;
 proc removeSession*(client: CopilotClient; sessionId: string) =
   ## Remove a session from the client's tracked sessions.
   client.sessions.del(sessionId)
+
+proc getForegroundSessionId*(client: CopilotClient): Future[string] {.async.} =
+  ## Get the foreground session ID from the server.
+  let res = await client.sendRpcRequest("session.getForeground", newJObject())
+  result = res["sessionId"].getStr()
+
+proc setForegroundSessionId*(client: CopilotClient; sessionId: string) {.async.} =
+  ## Set the foreground session to the given session ID.
+  let params = %*{"sessionId": sessionId}
+  let res = await client.sendRpcRequest("session.setForeground", params)
+  if not res{"success"}.getBool(false):
+    let errMsg = res{"error"}.getStr("Unknown")
+    raise newException(IOError,
+      "Failed to set foreground session: " & errMsg)

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.40-0",
+                "@github/copilot": "^1.0.40-1",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },
@@ -663,26 +663,26 @@
             }
         },
         "node_modules/@github/copilot": {
-            "version": "1.0.40-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-0.tgz",
-            "integrity": "sha512-KIrRqPOCGPcYUq09wvi66qUi5YMFTH5z9fOEzo1BuyLFVQqUen0TtRk0mpbhG6TxArLPqosBY8nDXOdc+NqKKw==",
+            "version": "1.0.40-1",
+            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-1.tgz",
+            "integrity": "sha512-jdohe7CcjlmbNR0bnL/uAbaYDtmqZnHcHo3t/ZspVb9vo7+yk7AdTc4AF4TpV7M/tCKc+ynoqgQNCalWAmXYWQ==",
             "license": "SEE LICENSE IN LICENSE.md",
             "bin": {
                 "copilot": "npm-loader.js"
             },
             "optionalDependencies": {
-                "@github/copilot-darwin-arm64": "1.0.40-0",
-                "@github/copilot-darwin-x64": "1.0.40-0",
-                "@github/copilot-linux-arm64": "1.0.40-0",
-                "@github/copilot-linux-x64": "1.0.40-0",
-                "@github/copilot-win32-arm64": "1.0.40-0",
-                "@github/copilot-win32-x64": "1.0.40-0"
+                "@github/copilot-darwin-arm64": "1.0.40-1",
+                "@github/copilot-darwin-x64": "1.0.40-1",
+                "@github/copilot-linux-arm64": "1.0.40-1",
+                "@github/copilot-linux-x64": "1.0.40-1",
+                "@github/copilot-win32-arm64": "1.0.40-1",
+                "@github/copilot-win32-x64": "1.0.40-1"
             }
         },
         "node_modules/@github/copilot-darwin-arm64": {
-            "version": "1.0.40-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-0.tgz",
-            "integrity": "sha512-l905DiMvOB7Jn5MAkS+iEQcM99hmJHQ5yrKaGJ9OteVWBCcxPEO5ctnRYFdeq4NHL+9OnAzJzNc0kwScOAUCzg==",
+            "version": "1.0.40-1",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-1.tgz",
+            "integrity": "sha512-DSArBmv1A6BstJs23QgXzes7B8Hu+sz4Ccqh1NhY/4NPfxck1rD2v61ZWz8kdwpgTdjP6lWSZ5nLWdi9Go+PhA==",
             "cpu": [
                 "arm64"
             ],
@@ -696,9 +696,9 @@
             }
         },
         "node_modules/@github/copilot-darwin-x64": {
-            "version": "1.0.40-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-0.tgz",
-            "integrity": "sha512-e/Dtc1CjZ5SpNLdtY7vHxzH3hhNKfiMJdyp/2UY/6rzXsSPfbw9xZL01nUBbZt0aYj2FbPBDMTyfqoh5weUSww==",
+            "version": "1.0.40-1",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-1.tgz",
+            "integrity": "sha512-fTOL2XChDSsPc/q//mIFlq47ABNgyUKqz1+ix5oxloE9RlT1YpD7v3O+dqU/tmdxXwMTfQqgZsYglRY/nna3yw==",
             "cpu": [
                 "x64"
             ],
@@ -712,9 +712,9 @@
             }
         },
         "node_modules/@github/copilot-linux-arm64": {
-            "version": "1.0.40-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-0.tgz",
-            "integrity": "sha512-fR/gVUXFpjwojNf3Pg5lH2vrb8q0Gghv6RK6xx1QS6pEBdPTMGeoPxQVqSSB6dZCR/X3dkK1tIZ5IGnuABDHbA==",
+            "version": "1.0.40-1",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-1.tgz",
+            "integrity": "sha512-+aon/9kAxgGlxLZrxzwUrNO1G/eUIhhEB6W4u1sMs2GwXjANrDr6WIsp056dOnU2TY9oEnn8vWTJQSIwyFlGHQ==",
             "cpu": [
                 "arm64"
             ],
@@ -728,9 +728,9 @@
             }
         },
         "node_modules/@github/copilot-linux-x64": {
-            "version": "1.0.40-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-0.tgz",
-            "integrity": "sha512-vDfE5Cxgg+BealbxBjqa0MUrLGJF+zT+XygMFgWXi/4ESVpRvvAet8rUoLeL+7Lgg6QRlS+UMPWfWL6ZAoSp5w==",
+            "version": "1.0.40-1",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-1.tgz",
+            "integrity": "sha512-p44TeuI01EpizsJmQX0W21f7pPXyTvrXYkv/5W1GgCiNEP4HKLG9rdgdIEtqaIMnXFKssxpGF45+hJuz0iep5g==",
             "cpu": [
                 "x64"
             ],
@@ -744,9 +744,9 @@
             }
         },
         "node_modules/@github/copilot-win32-arm64": {
-            "version": "1.0.40-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-0.tgz",
-            "integrity": "sha512-7aEo1CZ5476lWRtfcym0TX1DhH5l9+PKENHPOr8vfziHKeNlWYkXHVTo7OGIUnCAwIetbCQRyf92nnaFhG/8Jw==",
+            "version": "1.0.40-1",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-1.tgz",
+            "integrity": "sha512-nrbMh1qc8VWL1KU2N+VdQ2M+4jiGlugApIFNUbfywnUITktWEpQ62Jqf2YQlrMr51f1F1fjSE/YBuDW6InzzYg==",
             "cpu": [
                 "arm64"
             ],
@@ -760,9 +760,9 @@
             }
         },
         "node_modules/@github/copilot-win32-x64": {
-            "version": "1.0.40-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-0.tgz",
-            "integrity": "sha512-egnoilEO6TS0qSexe+A26GUSyfeinaqXJRTYL4Qr6eVgAfFhCEpCJtK/gHIZmlDXnq2ex3jGrVvz9+ZIp+JSoA==",
+            "version": "1.0.40-1",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-1.tgz",
+            "integrity": "sha512-n5qmzAn4OKbdHJeOmdt4eUA7XWSUOmNSJUtRswKVqgCxrmMOR/0FXCPzVS0gAJn+UEj9ApHulC6G09HR5Nhp7Q==",
             "cpu": [
                 "x64"
             ],

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.39",
+                "@github/copilot": "^1.0.40-0",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },
@@ -663,26 +663,26 @@
             }
         },
         "node_modules/@github/copilot": {
-            "version": "1.0.39",
-            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.39.tgz",
-            "integrity": "sha512-AY0VPYf6QQm88wUcOav2B36iedWKBUaMegKRxxY2uIHESiU6HueEuQR/n7D3U2UdD0zLox3jFRjYbZAsr2CgkQ==",
+            "version": "1.0.40-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-0.tgz",
+            "integrity": "sha512-KIrRqPOCGPcYUq09wvi66qUi5YMFTH5z9fOEzo1BuyLFVQqUen0TtRk0mpbhG6TxArLPqosBY8nDXOdc+NqKKw==",
             "license": "SEE LICENSE IN LICENSE.md",
             "bin": {
                 "copilot": "npm-loader.js"
             },
             "optionalDependencies": {
-                "@github/copilot-darwin-arm64": "1.0.39",
-                "@github/copilot-darwin-x64": "1.0.39",
-                "@github/copilot-linux-arm64": "1.0.39",
-                "@github/copilot-linux-x64": "1.0.39",
-                "@github/copilot-win32-arm64": "1.0.39",
-                "@github/copilot-win32-x64": "1.0.39"
+                "@github/copilot-darwin-arm64": "1.0.40-0",
+                "@github/copilot-darwin-x64": "1.0.40-0",
+                "@github/copilot-linux-arm64": "1.0.40-0",
+                "@github/copilot-linux-x64": "1.0.40-0",
+                "@github/copilot-win32-arm64": "1.0.40-0",
+                "@github/copilot-win32-x64": "1.0.40-0"
             }
         },
         "node_modules/@github/copilot-darwin-arm64": {
-            "version": "1.0.39",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.39.tgz",
-            "integrity": "sha512-E8WfNL43NMzMTDDpCiYikaEmYCMAr6mz8LHrJtkaFuVXVkBr/q2NI3hAtwHFy8M11Fac/MeIe3/VEymWwwh3kw==",
+            "version": "1.0.40-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-0.tgz",
+            "integrity": "sha512-l905DiMvOB7Jn5MAkS+iEQcM99hmJHQ5yrKaGJ9OteVWBCcxPEO5ctnRYFdeq4NHL+9OnAzJzNc0kwScOAUCzg==",
             "cpu": [
                 "arm64"
             ],
@@ -696,9 +696,9 @@
             }
         },
         "node_modules/@github/copilot-darwin-x64": {
-            "version": "1.0.39",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.39.tgz",
-            "integrity": "sha512-0zbC4lDVX7l8Wvq+JSCMjO0xTN69nWLejTBCl3Ev5bP6P+/7wPURcUvZKoHEaXxOULQ3AGj0DwZNAsvvQkA/6Q==",
+            "version": "1.0.40-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-0.tgz",
+            "integrity": "sha512-e/Dtc1CjZ5SpNLdtY7vHxzH3hhNKfiMJdyp/2UY/6rzXsSPfbw9xZL01nUBbZt0aYj2FbPBDMTyfqoh5weUSww==",
             "cpu": [
                 "x64"
             ],
@@ -712,9 +712,9 @@
             }
         },
         "node_modules/@github/copilot-linux-arm64": {
-            "version": "1.0.39",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.39.tgz",
-            "integrity": "sha512-x88FuByweJlHlAmUZXjq4JlmtqgoM57Fe7nXzQkGr2Y5wnc2EDydBzFYEOlYDSWozQreimaJIm0KEMAA5T8/Fg==",
+            "version": "1.0.40-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-0.tgz",
+            "integrity": "sha512-fR/gVUXFpjwojNf3Pg5lH2vrb8q0Gghv6RK6xx1QS6pEBdPTMGeoPxQVqSSB6dZCR/X3dkK1tIZ5IGnuABDHbA==",
             "cpu": [
                 "arm64"
             ],
@@ -728,9 +728,9 @@
             }
         },
         "node_modules/@github/copilot-linux-x64": {
-            "version": "1.0.39",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.39.tgz",
-            "integrity": "sha512-ssahg8r7a0VCsHVXPRmFFXx70xNAxaTM2SZfG7qPRfFB2OM8gHrW26F2oikTklDF6D+A2MfSAMpzJLBUZbPnhw==",
+            "version": "1.0.40-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-0.tgz",
+            "integrity": "sha512-vDfE5Cxgg+BealbxBjqa0MUrLGJF+zT+XygMFgWXi/4ESVpRvvAet8rUoLeL+7Lgg6QRlS+UMPWfWL6ZAoSp5w==",
             "cpu": [
                 "x64"
             ],
@@ -744,9 +744,9 @@
             }
         },
         "node_modules/@github/copilot-win32-arm64": {
-            "version": "1.0.39",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.39.tgz",
-            "integrity": "sha512-hhBWGZQIywbp6MBxlqMX2GSmHqtUAOGwpo9b0igscecL4i0kz89QNasC+mKiN+zFEHP6I8gggOu87XPI17Io8Q==",
+            "version": "1.0.40-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-0.tgz",
+            "integrity": "sha512-7aEo1CZ5476lWRtfcym0TX1DhH5l9+PKENHPOr8vfziHKeNlWYkXHVTo7OGIUnCAwIetbCQRyf92nnaFhG/8Jw==",
             "cpu": [
                 "arm64"
             ],
@@ -760,9 +760,9 @@
             }
         },
         "node_modules/@github/copilot-win32-x64": {
-            "version": "1.0.39",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.39.tgz",
-            "integrity": "sha512-0ehlMtBiwKjmfEY3hVZggdn7qrmPMC8ueBQv/b+6UY3SMRS/M/1Y7xkOCwG84NvJsktdSsk3SlQnE2LbkTVpSA==",
+            "version": "1.0.40-0",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-0.tgz",
+            "integrity": "sha512-egnoilEO6TS0qSexe+A26GUSyfeinaqXJRTYL4Qr6eVgAfFhCEpCJtK/gHIZmlDXnq2ex3jGrVvz9+ZIp+JSoA==",
             "cpu": [
                 "x64"
             ],

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.40-1",
+                "@github/copilot": "^1.0.40-3",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },
@@ -663,26 +663,26 @@
             }
         },
         "node_modules/@github/copilot": {
-            "version": "1.0.40-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-1.tgz",
-            "integrity": "sha512-jdohe7CcjlmbNR0bnL/uAbaYDtmqZnHcHo3t/ZspVb9vo7+yk7AdTc4AF4TpV7M/tCKc+ynoqgQNCalWAmXYWQ==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-3.tgz",
+            "integrity": "sha512-bgvE59bJFsT/tN2CvMR7f5a6NH1tWxYTl9skVrRDk4YS6ZcFP0bclYg/NMDR8D5sfQYngdNN8vxmv85eB8rPVA==",
             "license": "SEE LICENSE IN LICENSE.md",
             "bin": {
                 "copilot": "npm-loader.js"
             },
             "optionalDependencies": {
-                "@github/copilot-darwin-arm64": "1.0.40-1",
-                "@github/copilot-darwin-x64": "1.0.40-1",
-                "@github/copilot-linux-arm64": "1.0.40-1",
-                "@github/copilot-linux-x64": "1.0.40-1",
-                "@github/copilot-win32-arm64": "1.0.40-1",
-                "@github/copilot-win32-x64": "1.0.40-1"
+                "@github/copilot-darwin-arm64": "1.0.40-3",
+                "@github/copilot-darwin-x64": "1.0.40-3",
+                "@github/copilot-linux-arm64": "1.0.40-3",
+                "@github/copilot-linux-x64": "1.0.40-3",
+                "@github/copilot-win32-arm64": "1.0.40-3",
+                "@github/copilot-win32-x64": "1.0.40-3"
             }
         },
         "node_modules/@github/copilot-darwin-arm64": {
-            "version": "1.0.40-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-1.tgz",
-            "integrity": "sha512-DSArBmv1A6BstJs23QgXzes7B8Hu+sz4Ccqh1NhY/4NPfxck1rD2v61ZWz8kdwpgTdjP6lWSZ5nLWdi9Go+PhA==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-3.tgz",
+            "integrity": "sha512-QRVt15j3azPs8foceUfwT8COnR5DULOhc+5hUp8UgSJagNGEMv8zwVPYoWiJyeApeLdERDeqBF6M6MHHbMjD+A==",
             "cpu": [
                 "arm64"
             ],
@@ -696,9 +696,9 @@
             }
         },
         "node_modules/@github/copilot-darwin-x64": {
-            "version": "1.0.40-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-1.tgz",
-            "integrity": "sha512-fTOL2XChDSsPc/q//mIFlq47ABNgyUKqz1+ix5oxloE9RlT1YpD7v3O+dqU/tmdxXwMTfQqgZsYglRY/nna3yw==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-3.tgz",
+            "integrity": "sha512-8P2EBAtxjLfk8mG2DR9laWeX6WT4WkrHG+FcTciTNwzRy5YqaFAommwd+nc8I7ddktZvzgQEz8tdM8SAlQ2d2A==",
             "cpu": [
                 "x64"
             ],
@@ -712,9 +712,9 @@
             }
         },
         "node_modules/@github/copilot-linux-arm64": {
-            "version": "1.0.40-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-1.tgz",
-            "integrity": "sha512-+aon/9kAxgGlxLZrxzwUrNO1G/eUIhhEB6W4u1sMs2GwXjANrDr6WIsp056dOnU2TY9oEnn8vWTJQSIwyFlGHQ==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-3.tgz",
+            "integrity": "sha512-ItrOgrQ/2QKsrcUHvcSs/y/4HVypzNNFNF/0vL/30yDy89w+5z3hzydZ0uAyMHwf//sWJauAWdkQYmZqaSjT2A==",
             "cpu": [
                 "arm64"
             ],
@@ -728,9 +728,9 @@
             }
         },
         "node_modules/@github/copilot-linux-x64": {
-            "version": "1.0.40-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-1.tgz",
-            "integrity": "sha512-p44TeuI01EpizsJmQX0W21f7pPXyTvrXYkv/5W1GgCiNEP4HKLG9rdgdIEtqaIMnXFKssxpGF45+hJuz0iep5g==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-3.tgz",
+            "integrity": "sha512-WwRaJeqy+Ywx8XCKH1X/joLK1xbi6MLwWU+ZnRosr8pkvoLnewlBZRVT3dkxkPYvnTIn/PBJKjhtC2lgptbrTg==",
             "cpu": [
                 "x64"
             ],
@@ -744,9 +744,9 @@
             }
         },
         "node_modules/@github/copilot-win32-arm64": {
-            "version": "1.0.40-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-1.tgz",
-            "integrity": "sha512-nrbMh1qc8VWL1KU2N+VdQ2M+4jiGlugApIFNUbfywnUITktWEpQ62Jqf2YQlrMr51f1F1fjSE/YBuDW6InzzYg==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-3.tgz",
+            "integrity": "sha512-B/JvunL2xFJ6xGLppTehIotaEqEaWOYg+P929rpx90FG2GdsR5oQ5zVHTiMJWX6YFqmW+Kwc5utCMUj7MjDmQQ==",
             "cpu": [
                 "arm64"
             ],
@@ -760,9 +760,9 @@
             }
         },
         "node_modules/@github/copilot-win32-x64": {
-            "version": "1.0.40-1",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-1.tgz",
-            "integrity": "sha512-n5qmzAn4OKbdHJeOmdt4eUA7XWSUOmNSJUtRswKVqgCxrmMOR/0FXCPzVS0gAJn+UEj9ApHulC6G09HR5Nhp7Q==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-3.tgz",
+            "integrity": "sha512-80ZFwdKzpRTVjq3MHMU6LjsWjYlVEyI0+rFiM/5s5EmbQDvSnXt4vLT4O+UTbQs+YSi5jRLtm4Q6QkIChE7AWQ==",
             "cpu": [
                 "x64"
             ],

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -56,7 +56,7 @@
     "author": "GitHub",
     "license": "MIT",
     "dependencies": {
-        "@github/copilot": "^1.0.40-0",
+        "@github/copilot": "^1.0.40-1",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
     },

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -56,7 +56,7 @@
     "author": "GitHub",
     "license": "MIT",
     "dependencies": {
-        "@github/copilot": "^1.0.40-1",
+        "@github/copilot": "^1.0.40-3",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
     },

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -56,7 +56,7 @@
     "author": "GitHub",
     "license": "MIT",
     "dependencies": {
-        "@github/copilot": "^1.0.39",
+        "@github/copilot": "^1.0.40-0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
     },

--- a/nodejs/samples/package-lock.json
+++ b/nodejs/samples/package-lock.json
@@ -18,7 +18,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.40-1",
+                "@github/copilot": "^1.0.40-3",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },

--- a/nodejs/samples/package-lock.json
+++ b/nodejs/samples/package-lock.json
@@ -18,7 +18,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.39",
+                "@github/copilot": "^1.0.40-0",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },

--- a/nodejs/samples/package-lock.json
+++ b/nodejs/samples/package-lock.json
@@ -18,7 +18,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.40-0",
+                "@github/copilot": "^1.0.40-1",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },

--- a/nodejs/src/client.ts
+++ b/nodejs/src/client.ts
@@ -907,6 +907,7 @@ export class CopilotClient {
                 disabledSkills: config.disabledSkills,
                 infiniteSessions: config.infiniteSessions,
                 disableResume: config.disableResume,
+                continuePendingWork: config.continuePendingWork,
                 gitHubToken: config.gitHubToken,
             });
 

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -123,6 +123,8 @@ export type McpServerConfigLocalType = "local" | "stdio";
  * via the `definition` "McpServerConfigHttpType".
  */
 export type McpServerConfigHttpType = "http" | "sse";
+
+export type McpServerConfigHttpOauthGrantType = "authorization_code" | "client_credentials";
 /**
  * Connection status: connected, failed, needs-auth, pending, disabled, or not_configured
  *
@@ -878,6 +880,7 @@ export interface McpServerConfigHttp {
   };
   oauthClientId?: string;
   oauthPublicClient?: boolean;
+  oauthGrantType?: McpServerConfigHttpOauthGrantType;
 }
 
 export interface McpConfigDisableRequest {

--- a/nodejs/src/generated/rpc.ts
+++ b/nodejs/src/generated/rpc.ts
@@ -40,6 +40,42 @@ export type ExtensionSource = "project" | "user";
  * via the `definition` "ExtensionStatus".
  */
 export type ExtensionStatus = "running" | "disabled" | "failed" | "starting";
+/**
+ * Tool call result (string or expanded result object)
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolResult".
+ */
+export type ExternalToolResult = string | ExternalToolTextResultForLlm;
+/**
+ * A content block within a tool result, which may be text, terminal output, image, audio, or a resource
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContent".
+ */
+export type ExternalToolTextResultForLlmContent =
+  | ExternalToolTextResultForLlmContentText
+  | ExternalToolTextResultForLlmContentTerminal
+  | ExternalToolTextResultForLlmContentImage
+  | ExternalToolTextResultForLlmContentAudio
+  | ExternalToolTextResultForLlmContentResourceLink
+  | ExternalToolTextResultForLlmContentResource;
+/**
+ * Theme variant this icon is intended for
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResourceLinkIconTheme".
+ */
+export type ExternalToolTextResultForLlmContentResourceLinkIconTheme = "light" | "dark";
+/**
+ * The embedded resource contents, either text or base64-encoded binary
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResourceDetails".
+ */
+export type ExternalToolTextResultForLlmContentResourceDetails =
+  | EmbeddedTextResourceContents
+  | EmbeddedBlobResourceContents;
 
 export type FilterMapping =
   | {
@@ -113,6 +149,7 @@ export type PermissionDecision =
   | PermissionDecisionApproveOnce
   | PermissionDecisionApproveForSession
   | PermissionDecisionApproveForLocation
+  | PermissionDecisionApprovePermanently
   | PermissionDecisionReject
   | PermissionDecisionUserNotAvailable;
 /**
@@ -208,13 +245,6 @@ export type TaskShellInfoAttachmentMode = "attached" | "detached";
  * via the `definition` "TaskShellInfoExecutionMode".
  */
 export type TaskShellInfoExecutionMode = "sync" | "background";
-/**
- * Tool call result (string or expanded result object)
- *
- * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ToolsHandlePendingToolCall".
- */
-export type ToolsHandlePendingToolCall = string | ToolCallResult;
 
 export type UIElicitationFieldValue = string | number | boolean | string[];
 
@@ -383,6 +413,36 @@ export interface DiscoveredMcpServer {
   enabled: boolean;
 }
 
+export interface EmbeddedBlobResourceContents {
+  /**
+   * URI identifying the resource
+   */
+  uri: string;
+  /**
+   * MIME type of the blob content
+   */
+  mimeType?: string;
+  /**
+   * Base64-encoded binary content of the resource
+   */
+  blob: string;
+}
+
+export interface EmbeddedTextResourceContents {
+  /**
+   * URI identifying the resource
+   */
+  uri: string;
+  /**
+   * MIME type of the text content
+   */
+  mimeType?: string;
+  /**
+   * Text content of the resource
+   */
+  text: string;
+}
+
 export interface Extension {
   /**
    * Source-qualified ID (e.g., 'project:my-ext', 'user:auth-helper')
@@ -423,6 +483,195 @@ export interface ExtensionsEnableRequest {
    */
   id: string;
 }
+/**
+ * Expanded external tool result payload
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlm".
+ */
+export interface ExternalToolTextResultForLlm {
+  /**
+   * Text result returned to the model
+   */
+  textResultForLlm: string;
+  /**
+   * Execution outcome classification. Optional for back-compat; normalized to 'success' (or 'failure' when error is present) when missing or unrecognized.
+   */
+  resultType?: string;
+  /**
+   * Optional error message for failed executions
+   */
+  error?: string;
+  /**
+   * Detailed log content for timeline display
+   */
+  sessionLog?: string;
+  /**
+   * Optional tool-specific telemetry
+   */
+  toolTelemetry?: {
+    [k: string]: unknown;
+  };
+  /**
+   * Structured content blocks from the tool
+   */
+  contents?: ExternalToolTextResultForLlmContent[];
+  [k: string]: unknown;
+}
+/**
+ * Plain text content block
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentText".
+ */
+export interface ExternalToolTextResultForLlmContentText {
+  /**
+   * Content block type discriminator
+   */
+  type: "text";
+  /**
+   * The text content
+   */
+  text: string;
+}
+/**
+ * Terminal/shell output content block with optional exit code and working directory
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentTerminal".
+ */
+export interface ExternalToolTextResultForLlmContentTerminal {
+  /**
+   * Content block type discriminator
+   */
+  type: "terminal";
+  /**
+   * Terminal/shell output text
+   */
+  text: string;
+  /**
+   * Process exit code, if the command has completed
+   */
+  exitCode?: number;
+  /**
+   * Working directory where the command was executed
+   */
+  cwd?: string;
+}
+/**
+ * Image content block with base64-encoded data
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentImage".
+ */
+export interface ExternalToolTextResultForLlmContentImage {
+  /**
+   * Content block type discriminator
+   */
+  type: "image";
+  /**
+   * Base64-encoded image data
+   */
+  data: string;
+  /**
+   * MIME type of the image (e.g., image/png, image/jpeg)
+   */
+  mimeType: string;
+}
+/**
+ * Audio content block with base64-encoded data
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentAudio".
+ */
+export interface ExternalToolTextResultForLlmContentAudio {
+  /**
+   * Content block type discriminator
+   */
+  type: "audio";
+  /**
+   * Base64-encoded audio data
+   */
+  data: string;
+  /**
+   * MIME type of the audio (e.g., audio/wav, audio/mpeg)
+   */
+  mimeType: string;
+}
+/**
+ * Resource link content block referencing an external resource
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResourceLink".
+ */
+export interface ExternalToolTextResultForLlmContentResourceLink {
+  /**
+   * Icons associated with this resource
+   */
+  icons?: ExternalToolTextResultForLlmContentResourceLinkIcon[];
+  /**
+   * Resource name identifier
+   */
+  name: string;
+  /**
+   * Human-readable display title for the resource
+   */
+  title?: string;
+  /**
+   * URI identifying the resource
+   */
+  uri: string;
+  /**
+   * Human-readable description of the resource
+   */
+  description?: string;
+  /**
+   * MIME type of the resource content
+   */
+  mimeType?: string;
+  /**
+   * Size of the resource in bytes
+   */
+  size?: number;
+  /**
+   * Content block type discriminator
+   */
+  type: "resource_link";
+}
+/**
+ * Icon image for a resource
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResourceLinkIcon".
+ */
+export interface ExternalToolTextResultForLlmContentResourceLinkIcon {
+  /**
+   * URL or path to the icon image
+   */
+  src: string;
+  /**
+   * MIME type of the icon image
+   */
+  mimeType?: string;
+  /**
+   * Available icon sizes (e.g., ['16x16', '32x32'])
+   */
+  sizes?: string[];
+  theme?: ExternalToolTextResultForLlmContentResourceLinkIconTheme;
+}
+/**
+ * Embedded resource content block with inline text or binary data
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResource".
+ */
+export interface ExternalToolTextResultForLlmContentResource {
+  /**
+   * Content block type discriminator
+   */
+  type: "resource";
+  resource: ExternalToolTextResultForLlmContentResourceDetails;
+}
 
 /** @experimental */
 export interface FleetStartRequest {
@@ -440,7 +689,19 @@ export interface FleetStartResult {
   started: boolean;
 }
 
-export interface HandleToolCallResult {
+export interface HandlePendingToolCallRequest {
+  /**
+   * Request ID of the pending tool call
+   */
+  requestId: string;
+  result?: ExternalToolResult;
+  /**
+   * Error message if the tool call failed
+   */
+  error?: string;
+}
+
+export interface HandlePendingToolCallResult {
   /**
    * Whether the tool call result was handled successfully
    */
@@ -966,7 +1227,11 @@ export interface PermissionDecisionApproveForSession {
    * Approved and remembered for the rest of the session
    */
   kind: "approve-for-session";
-  approval: PermissionDecisionApproveForSessionApproval;
+  approval?: PermissionDecisionApproveForSessionApproval;
+  /**
+   * The URL domain to approve for this session
+   */
+  domain?: string;
 }
 
 export interface PermissionDecisionApproveForSessionApprovalCommands {
@@ -1045,6 +1310,17 @@ export interface PermissionDecisionApproveForLocationApprovalMemory {
 export interface PermissionDecisionApproveForLocationApprovalCustomTool {
   kind: "custom-tool";
   toolName: string;
+}
+
+export interface PermissionDecisionApprovePermanently {
+  /**
+   * Approved and persisted across sessions
+   */
+  kind: "approve-permanently";
+  /**
+   * The URL domain to approve permanently
+   */
+  domain: string;
 }
 
 export interface PermissionDecisionReject {
@@ -1827,44 +2103,11 @@ export interface Tool {
   instructions?: string;
 }
 
-export interface ToolCallResult {
-  /**
-   * Text result to send back to the LLM
-   */
-  textResultForLlm: string;
-  /**
-   * Type of the tool result
-   */
-  resultType?: string;
-  /**
-   * Error message if the tool call failed
-   */
-  error?: string;
-  /**
-   * Telemetry data from tool execution
-   */
-  toolTelemetry?: {
-    [k: string]: unknown;
-  };
-}
-
 export interface ToolList {
   /**
    * List of available built-in tools with metadata
    */
   tools: Tool[];
-}
-
-export interface ToolsHandlePendingToolCallRequest {
-  /**
-   * Request ID of the pending tool call
-   */
-  requestId: string;
-  result?: ToolsHandlePendingToolCall;
-  /**
-   * Error message if the tool call failed
-   */
-  error?: string;
 }
 
 export interface ToolsListRequest {
@@ -2031,6 +2274,16 @@ export interface UsageGetMetricsResult {
    */
   totalUserRequests: number;
   /**
+   * Session-wide accumulated nano-AI units cost
+   */
+  totalNanoAiu?: number;
+  /**
+   * Session-wide per-token-type accumulated token counts
+   */
+  tokenDetails?: {
+    [k: string]: UsageMetricsTokenDetail;
+  };
+  /**
    * Total time spent in model API calls (milliseconds)
    */
   totalApiDurationMs: number;
@@ -2058,6 +2311,13 @@ export interface UsageGetMetricsResult {
    */
   lastCallOutputTokens: number;
 }
+
+export interface UsageMetricsTokenDetail {
+  /**
+   * Accumulated token count for this token type
+   */
+  tokenCount: number;
+}
 /**
  * Aggregated code change metrics
  *
@@ -2082,6 +2342,16 @@ export interface UsageMetricsCodeChanges {
 export interface UsageMetricsModelMetric {
   requests: UsageMetricsModelMetricRequests;
   usage: UsageMetricsModelMetricUsage;
+  /**
+   * Accumulated nano-AI units cost for this model
+   */
+  totalNanoAiu?: number;
+  /**
+   * Token count details per type
+   */
+  tokenDetails?: {
+    [k: string]: UsageMetricsModelMetricTokenDetail;
+  };
 }
 /**
  * Request count and cost metrics for this model
@@ -2126,6 +2396,13 @@ export interface UsageMetricsModelMetricUsage {
    * Total output tokens used for reasoning
    */
   reasoningTokens?: number;
+}
+
+export interface UsageMetricsModelMetricTokenDetail {
+  /**
+   * Accumulated token count for this token type
+   */
+  tokenCount: number;
 }
 
 export interface WorkspacesCreateFileRequest {
@@ -2363,7 +2640,7 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 connection.sendRequest("session.extensions.reload", { sessionId }),
         },
         tools: {
-            handlePendingToolCall: async (params: ToolsHandlePendingToolCallRequest): Promise<HandleToolCallResult> =>
+            handlePendingToolCall: async (params: HandlePendingToolCallRequest): Promise<HandlePendingToolCallResult> =>
                 connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params }),
         },
         commands: {

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -156,7 +156,8 @@ export type SystemNotification =
   | SystemNotificationAgentIdle
   | SystemNotificationNewInboxMessage
   | SystemNotificationShellCompleted
-  | SystemNotificationShellDetachedCompleted;
+  | SystemNotificationShellDetachedCompleted
+  | SystemNotificationInstructionDiscovered;
 /**
  * Whether the agent completed successfully or failed
  */
@@ -3207,6 +3208,25 @@ export interface SystemNotificationShellDetachedCompleted {
    */
   shellId: string;
   type: "shell_detached_completed";
+}
+export interface SystemNotificationInstructionDiscovered {
+  /**
+   * Human-readable label for the timeline (e.g., 'AGENTS.md from packages/billing/')
+   */
+  description?: string;
+  /**
+   * Relative path to the discovered instruction file
+   */
+  sourcePath: string;
+  /**
+   * Path of the file access that triggered discovery
+   */
+  triggerFile: string;
+  /**
+   * Tool command that triggered discovery (currently always 'view')
+   */
+  triggerTool: string;
+  type: "instruction_discovered";
 }
 export interface PermissionRequestedEvent {
   /**

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -208,17 +208,28 @@ export type PermissionPromptRequestMemoryDirection = "upvote" | "downvote";
  */
 export type PermissionPromptRequestPathAccessKind = "read" | "shell" | "write";
 /**
- * The outcome of the permission request
+ * The result of the permission request
  */
-export type PermissionCompletedKind =
-  | "approved"
-  | "approved-for-session"
-  | "approved-for-location"
-  | "denied-by-rules"
-  | "denied-no-approval-rule-and-could-not-request-from-user"
-  | "denied-interactively-by-user"
-  | "denied-by-content-exclusion-policy"
-  | "denied-by-permission-request-hook";
+export type PermissionResult =
+  | PermissionApproved
+  | PermissionApprovedForSession
+  | PermissionApprovedForLocation
+  | PermissionCancelled
+  | PermissionDeniedByRules
+  | PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser
+  | PermissionDeniedInteractivelyByUser
+  | PermissionDeniedByContentExclusionPolicy
+  | PermissionDeniedByPermissionRequestHook;
+/**
+ * The approval to add as a session-scoped rule
+ */
+export type UserToolSessionApproval =
+  | UserToolSessionApprovalCommands
+  | UserToolSessionApprovalRead
+  | UserToolSessionApprovalWrite
+  | UserToolSessionApprovalMcp
+  | UserToolSessionApprovalMemory
+  | UserToolSessionApprovalCustomTool;
 /**
  * Elicitation mode; "form" for structured input, "url" for browser-based. Defaults to "form" when absent.
  */
@@ -391,6 +402,10 @@ export interface ResumeData {
   alreadyInUse?: boolean;
   context?: WorkingDirectoryContext;
   /**
+   * When true, tool calls and permission requests left in flight by the previous session lifetime remain pending after resume and the agentic loop awaits their results. User sends are queued behind the pending work until all such requests reach a terminal state. When false (the default), any such tool calls and permission requests are immediately marked as interrupted on resume.
+   */
+  continuePendingWork?: boolean;
+  /**
    * Total number of persisted events in the session at the time of resume
    */
   eventCount: number;
@@ -410,6 +425,10 @@ export interface ResumeData {
    * Model currently selected at resume time
    */
   selectedModel?: string;
+  /**
+   * True when this resume attached to a session that the runtime already had running in-memory (for example, an extension joining a session another client was actively driving). False (or omitted) for cold resumes — the runtime had to reconstitute the session from its persisted event log.
+   */
+  sessionWasActive?: boolean;
 }
 export interface RemoteSteerableChangedEvent {
   /**
@@ -1025,6 +1044,12 @@ export interface ShutdownData {
    */
   systemTokens?: number;
   /**
+   * Session-wide per-token-type accumulated token counts
+   */
+  tokenDetails?: {
+    [k: string]: ShutdownTokenDetail;
+  };
+  /**
    * Tool definitions token count at shutdown
    */
   toolDefinitionsTokens?: number;
@@ -1032,6 +1057,10 @@ export interface ShutdownData {
    * Cumulative time spent in API calls during the session, in milliseconds
    */
   totalApiDurationMs: number;
+  /**
+   * Session-wide accumulated nano-AI units cost
+   */
+  totalNanoAiu?: number;
   /**
    * Total number of premium API requests used during the session
    */
@@ -1056,6 +1085,16 @@ export interface ShutdownCodeChanges {
 }
 export interface ShutdownModelMetric {
   requests: ShutdownModelMetricRequests;
+  /**
+   * Token count details per type
+   */
+  tokenDetails?: {
+    [k: string]: ShutdownModelMetricTokenDetail;
+  };
+  /**
+   * Accumulated nano-AI units cost for this model
+   */
+  totalNanoAiu?: number;
   usage: ShutdownModelMetricUsage;
 }
 /**
@@ -1070,6 +1109,12 @@ export interface ShutdownModelMetricRequests {
    * Total number of API requests made to this model
    */
   count: number;
+}
+export interface ShutdownModelMetricTokenDetail {
+  /**
+   * Accumulated token count for this token type
+   */
+  tokenCount: number;
 }
 /**
  * Token usage breakdown
@@ -1095,6 +1140,12 @@ export interface ShutdownModelMetricUsage {
    * Total reasoning tokens produced across all requests to this model
    */
   reasoningTokens?: number;
+}
+export interface ShutdownTokenDetail {
+  /**
+   * Accumulated token count for this token type
+   */
+  tokenCount: number;
 }
 export interface ContextChangedEvent {
   /**
@@ -1340,7 +1391,7 @@ export interface CompactionCompleteCompactionTokensUsedCopilotUsage {
    */
   tokenDetails: CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail[];
   /**
-   * Total cost in nano-AIU (AI Units) for this request
+   * Total cost in nano-AI units for this request
    */
   totalNanoAiu: number;
 }
@@ -1444,6 +1495,10 @@ export interface UserMessageData {
    * Path-backed native document attachments that stayed on the tagged_files path flow because native upload would exceed the request size limit
    */
   nativeDocumentPathFallbackPaths?: string[];
+  /**
+   * Parent agent task ID for background telemetry correlated to this user turn
+   */
+  parentAgentTaskId?: string;
   /**
    * Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user)
    */
@@ -1873,6 +1928,10 @@ export interface AssistantMessageData {
    * Tool invocations requested by the assistant in this message
    */
   toolRequests?: AssistantMessageToolRequest[];
+  /**
+   * Identifier for the agent loop turn that produced this message, matching the corresponding assistant.turn_start event
+   */
+  turnId?: string;
 }
 /**
  * A tool invocation request from the assistant
@@ -2081,7 +2140,7 @@ export interface AssistantUsageCopilotUsage {
    */
   tokenDetails: AssistantUsageCopilotUsageTokenDetail[];
   /**
-   * Total cost in nano-AIU (AI Units) for this request
+   * Total cost in nano-AI units for this request
    */
   totalNanoAiu: number;
 }
@@ -2326,6 +2385,10 @@ export interface ToolExecutionStartData {
    * Name of the tool being executed
    */
   toolName: string;
+  /**
+   * Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event
+   */
+  turnId?: string;
 }
 export interface ToolExecutionPartialResultEvent {
   /**
@@ -2456,6 +2519,10 @@ export interface ToolExecutionCompleteData {
   toolTelemetry?: {
     [k: string]: unknown;
   };
+  /**
+   * Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event
+   */
+  turnId?: string;
 }
 /**
  * Error details when the tool execution failed
@@ -3234,7 +3301,10 @@ export interface PermissionRequestedEvent {
    */
   agentId?: string;
   data: PermissionRequestedData;
-  ephemeral: true;
+  /**
+   * When true, the event is transient and not persisted to the session event log on disk
+   */
+  ephemeral?: boolean;
   /**
    * Unique event identifier (UUID v4), generated when the event is emitted
    */
@@ -3763,7 +3833,10 @@ export interface PermissionCompletedEvent {
    */
   agentId?: string;
   data: PermissionCompletedData;
-  ephemeral: true;
+  /**
+   * When true, the event is transient and not persisted to the session event log on disk
+   */
+  ephemeral?: boolean;
   /**
    * Unique event identifier (UUID v4), generated when the event is emitted
    */
@@ -3786,17 +3859,165 @@ export interface PermissionCompletedData {
    * Request ID of the resolved permission request; clients should dismiss any UI for this request
    */
   requestId: string;
-  result: PermissionCompletedResult;
+  result: PermissionResult;
   /**
    * Optional tool call ID associated with this permission prompt; clients may use it to correlate UI created from tool-scoped prompts
    */
   toolCallId?: string;
 }
-/**
- * The result of the permission request
- */
-export interface PermissionCompletedResult {
-  kind: PermissionCompletedKind;
+export interface PermissionApproved {
+  /**
+   * The permission request was approved
+   */
+  kind: "approved";
+}
+export interface PermissionApprovedForSession {
+  approval: UserToolSessionApproval;
+  /**
+   * Approved and remembered for the rest of the session
+   */
+  kind: "approved-for-session";
+}
+export interface UserToolSessionApprovalCommands {
+  /**
+   * Command identifiers approved by the user
+   */
+  commandIdentifiers: string[];
+  /**
+   * Command approval kind
+   */
+  kind: "commands";
+}
+export interface UserToolSessionApprovalRead {
+  /**
+   * Read approval kind
+   */
+  kind: "read";
+}
+export interface UserToolSessionApprovalWrite {
+  /**
+   * Write approval kind
+   */
+  kind: "write";
+}
+export interface UserToolSessionApprovalMcp {
+  /**
+   * MCP tool approval kind
+   */
+  kind: "mcp";
+  /**
+   * MCP server name
+   */
+  serverName: string;
+  /**
+   * Optional MCP tool name, or null for all tools on the server
+   */
+  toolName: string | null;
+}
+export interface UserToolSessionApprovalMemory {
+  /**
+   * Memory approval kind
+   */
+  kind: "memory";
+}
+export interface UserToolSessionApprovalCustomTool {
+  /**
+   * Custom tool approval kind
+   */
+  kind: "custom-tool";
+  /**
+   * Custom tool name
+   */
+  toolName: string;
+}
+export interface PermissionApprovedForLocation {
+  approval: UserToolSessionApproval;
+  /**
+   * Approved and persisted for this project location
+   */
+  kind: "approved-for-location";
+  /**
+   * The location key (git root or cwd) to persist the approval to
+   */
+  locationKey: string;
+}
+export interface PermissionCancelled {
+  /**
+   * The permission request was cancelled before a response was used
+   */
+  kind: "cancelled";
+  /**
+   * Optional explanation of why the request was cancelled
+   */
+  reason?: string;
+}
+export interface PermissionDeniedByRules {
+  /**
+   * Denied because approval rules explicitly blocked it
+   */
+  kind: "denied-by-rules";
+  /**
+   * Rules that denied the request
+   */
+  rules: PermissionRule[];
+}
+export interface PermissionRule {
+  /**
+   * Optional rule argument matched against the request
+   */
+  argument: string | null;
+  /**
+   * The rule kind, such as Shell or GitHubMCP
+   */
+  kind: string;
+}
+export interface PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser {
+  /**
+   * Denied because no approval rule matched and user confirmation was unavailable
+   */
+  kind: "denied-no-approval-rule-and-could-not-request-from-user";
+}
+export interface PermissionDeniedInteractivelyByUser {
+  /**
+   * Optional feedback from the user explaining the denial
+   */
+  feedback?: string;
+  /**
+   * Whether to force-reject the current agent turn
+   */
+  forceReject?: boolean;
+  /**
+   * Denied by the user during an interactive prompt
+   */
+  kind: "denied-interactively-by-user";
+}
+export interface PermissionDeniedByContentExclusionPolicy {
+  /**
+   * Denied by the organization's content exclusion policy
+   */
+  kind: "denied-by-content-exclusion-policy";
+  /**
+   * Human-readable explanation of why the path was excluded
+   */
+  message: string;
+  /**
+   * File path that triggered the exclusion
+   */
+  path: string;
+}
+export interface PermissionDeniedByPermissionRequestHook {
+  /**
+   * Whether to interrupt the current agent turn
+   */
+  interrupt?: boolean;
+  /**
+   * Denied by a permission request hook registered by an extension or plugin
+   */
+  kind: "denied-by-permission-request-hook";
+  /**
+   * Optional message from the hook explaining the denial
+   */
+  message?: string;
 }
 export interface UserInputRequestedEvent {
   /**
@@ -4144,7 +4365,10 @@ export interface ExternalToolRequestedEvent {
    */
   agentId?: string;
   data: ExternalToolRequestedData;
-  ephemeral: true;
+  /**
+   * When true, the event is transient and not persisted to the session event log on disk
+   */
+  ephemeral?: boolean;
   /**
    * Unique event identifier (UUID v4), generated when the event is emitted
    */
@@ -4200,7 +4424,7 @@ export interface ExternalToolCompletedEvent {
    */
   agentId?: string;
   data: ExternalToolCompletedData;
-  ephemeral: true;
+  ephemeral?: true;
   /**
    * Unique event identifier (UUID v4), generated when the event is emitted
    */

--- a/nodejs/src/generated/session-events.ts
+++ b/nodejs/src/generated/session-events.ts
@@ -4325,6 +4325,10 @@ export interface McpOauthRequiredStaticClientConfig {
    */
   clientId: string;
   /**
+   * Optional non-default OAuth grant type. When set to 'client_credentials', the OAuth flow runs headlessly using the client_id + keychain-stored secret (no browser, no callback server).
+   */
+  grantType?: "client_credentials";
+  /**
    * Whether this is a public OAuth client
    */
   publicClient?: boolean;

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -1421,6 +1421,18 @@ export type ResumeSessionConfig = Pick<
      * @default false
      */
     disableResume?: boolean;
+    /**
+     * When true, the runtime continues any tool calls or permission prompts that were
+     * still pending when the session was last suspended. When false (the default), the
+     * runtime treats pending work as interrupted on resume.
+     *
+     * For permission requests, the runtime re-emits `permission.requested` so the
+     * registered `onPermissionRequest` handler can re-prompt; for external tool calls,
+     * the consumer is expected to supply the result via the corresponding low-level
+     * RPC method.
+     * @default false
+     */
+    continuePendingWork?: boolean;
 };
 
 /**

--- a/nodejs/test/client.test.ts
+++ b/nodejs/test/client.test.ts
@@ -166,6 +166,47 @@ describe("CopilotClient", () => {
         spy.mockRestore();
     });
 
+    it("forwards continuePendingWork in session.resume request", async () => {
+        const client = new CopilotClient();
+        await client.start();
+        onTestFinished(() => client.forceStop());
+
+        const session = await client.createSession({ onPermissionRequest: approveAll });
+        const spy = vi
+            .spyOn((client as any).connection!, "sendRequest")
+            .mockImplementation(async (method: string, params: any) => {
+                if (method === "session.resume") return { sessionId: params.sessionId };
+                throw new Error(`Unexpected method: ${method}`);
+            });
+        await client.resumeSession(session.sessionId, {
+            onPermissionRequest: approveAll,
+            continuePendingWork: true,
+        });
+
+        const payload = spy.mock.calls.find((c) => c[0] === "session.resume")![1] as any;
+        expect(payload.continuePendingWork).toBe(true);
+        spy.mockRestore();
+    });
+
+    it("omits continuePendingWork from session.resume payload when not specified", async () => {
+        const client = new CopilotClient();
+        await client.start();
+        onTestFinished(() => client.forceStop());
+
+        const session = await client.createSession({ onPermissionRequest: approveAll });
+        const spy = vi
+            .spyOn((client as any).connection!, "sendRequest")
+            .mockImplementation(async (method: string, params: any) => {
+                if (method === "session.resume") return { sessionId: params.sessionId };
+                throw new Error(`Unexpected method: ${method}`);
+            });
+        await client.resumeSession(session.sessionId, { onPermissionRequest: approveAll });
+
+        const payload = spy.mock.calls.find((c) => c[0] === "session.resume")![1] as any;
+        expect(payload.continuePendingWork).toBeUndefined();
+        spy.mockRestore();
+    });
+
     it("forwards provider headers in session.create request", async () => {
         const client = new CopilotClient();
         await client.start();

--- a/nodejs/test/e2e/harness/sdkTestContext.ts
+++ b/nodejs/test/e2e/harness/sdkTestContext.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from "url";
 import { afterAll, afterEach, beforeEach, onTestFailed, TestContext } from "vitest";
 import { CopilotClient, CopilotClientOptions } from "../../../src";
 import { CapiProxy } from "./CapiProxy";
-import { retry } from "./sdkTestHelper";
+import { retry, formatError } from "./sdkTestHelper";
 
 export const isCI = process.env.GITHUB_ACTIONS === "true";
 
@@ -111,6 +111,17 @@ function getTrafficCapturePath(testContext: TestContext): string {
     return join(SNAPSHOTS_DIR, testFileName, `${taskNameAsFilename}.yaml`);
 }
 
-function rmDir(message: string, path: string): Promise<void> {
-    return retry(message, () => rm(path, { recursive: true, force: true }), 5, 2000);
+async function rmDir(message: string, path: string): Promise<void> {
+    // Use longer retries to tolerate Windows holding SQLite session-store.db
+    // open briefly after the CLI subprocess exits. If the temp dir still can't
+    // be removed (e.g. CLI background writer racing with cleanup), warn and
+    // continue rather than failing the whole test run — the OS / CI runner
+    // will reclaim the temp dir on shutdown.
+    try {
+        await retry(message, () => rm(path, { recursive: true, force: true }), 30, 1000);
+    } catch (error) {
+        console.warn(
+            `WARN: ${message} failed; leaving temp dir for OS cleanup: ${formatError(error)}`
+        );
+    }
 }

--- a/objc/src/CPCopilotClient.h
+++ b/objc/src/CPCopilotClient.h
@@ -68,6 +68,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setForeground:(NSString *)sessionId
            completion:(void (^)(NSError * _Nullable error))completion;
 
+/// Gets the foreground session ID.
+- (void)getForegroundSessionIdWithCompletion:(void (^)(NSString * _Nullable sessionId,
+                                                       NSError * _Nullable error))completion;
+
 /// Lists all sessions known to the server.
 - (void)listSessionsWithCompletion:(void (^)(NSArray<CPSessionMetadata *> * _Nullable sessions,
                                              NSError * _Nullable error))completion;

--- a/objc/src/CPCopilotClient.m
+++ b/objc/src/CPCopilotClient.m
@@ -438,10 +438,37 @@ static NSString *const kCPClientErrorDomain = @"CPCopilotClientErrorDomain";
 
 - (void)setForeground:(NSString *)sessionId
            completion:(void (^)(NSError * _Nullable))completion {
-    [self.rpcClient sendRequest:@"setForeground"
+    [self.rpcClient sendRequest:@"session.setForeground"
                          params:@{@"sessionId": sessionId}
                      completion:^(NSDictionary *result, NSError *error) {
-        completion(error);
+        if (error) {
+            completion(error);
+            return;
+        }
+        NSNumber *success = result[@"success"];
+        if (![success boolValue]) {
+            NSString *errMsg = result[@"error"] ?: @"Unknown error";
+            NSError *failError = [NSError errorWithDomain:kCPClientErrorDomain
+                                                     code:-7
+                                                 userInfo:@{NSLocalizedDescriptionKey:
+                                                     [NSString stringWithFormat:@"Failed to set foreground session: %@", errMsg]}];
+            completion(failError);
+            return;
+        }
+        completion(nil);
+    }];
+}
+
+- (void)getForegroundSessionIdWithCompletion:(void (^)(NSString * _Nullable, NSError * _Nullable))completion {
+    [self.rpcClient sendRequest:@"session.getForeground"
+                         params:@{}
+                     completion:^(NSDictionary *result, NSError *error) {
+        if (error) {
+            completion(nil, error);
+            return;
+        }
+        NSString *sessionId = result[@"sessionId"];
+        completion(sessionId, nil);
     }];
 }
 

--- a/ocaml/lib/client.ml
+++ b/ocaml/lib/client.ml
@@ -205,6 +205,27 @@ let list_models (t : t) : Types.model_info list Lwt.t =
          match Types.model_info_of_yojson j with Ok m -> Some m | Error _ -> None)
        models)
 
+let get_foreground_session_id (t : t) : string Lwt.t =
+  let open Lwt.Syntax in
+  let rpc = get_rpc t in
+  let* result = Jsonrpc.send_request rpc "session.getForeground" (`Assoc []) in
+  let open Yojson.Safe.Util in
+  Lwt.return (result |> member "sessionId" |> to_string)
+
+let set_foreground_session_id (t : t) (session_id : string) : unit Lwt.t =
+  let open Lwt.Syntax in
+  let rpc = get_rpc t in
+  let params = `Assoc [ ("sessionId", `String session_id) ] in
+  let* result = Jsonrpc.send_request rpc "session.setForeground" params in
+  let open Yojson.Safe.Util in
+  let success = try result |> member "success" |> to_bool with _ -> false in
+  if not success then
+    let err =
+      try result |> member "error" |> to_string with _ -> "Unknown"
+    in
+    Lwt.fail_with (Printf.sprintf "Failed to set foreground session: %s" err)
+  else Lwt.return_unit
+
 (* ========================================================================== *)
 (* State inspection                                                           *)
 (* ========================================================================== *)

--- a/perl/lib/GitHub/Copilot/Client.pm
+++ b/perl/lib/GitHub/Copilot/Client.pm
@@ -278,6 +278,25 @@ sub list_sessions {
     return \@sessions;
 }
 
+sub get_foreground_session_id {
+    my ($self) = @_;
+    $self->_ensure_connected();
+
+    my $response = $self->{_client}->request('session.getForeground', {});
+    return $response->{sessionId};
+}
+
+sub set_foreground_session_id {
+    my ($self, $session_id) = @_;
+    $self->_ensure_connected();
+
+    my $response = $self->{_client}->request('session.setForeground', { sessionId => $session_id });
+    if (!$response->{success}) {
+        my $error = $response->{error} // 'Unknown error';
+        croak "Failed to set foreground session: $error";
+    }
+}
+
 # --------------------------------------------------------------------------
 # Ping and status
 # --------------------------------------------------------------------------

--- a/python/copilot/client.py
+++ b/python/copilot/client.py
@@ -1513,6 +1513,7 @@ class CopilotClient:
         on_elicitation_request: ElicitationHandler | None = None,
         create_session_fs_handler: CreateSessionFsHandler | None = None,
         github_token: str | None = None,
+        continue_pending_work: bool | None = None,
     ) -> CopilotSession:
         """
         Resume an existing conversation session by its ID.
@@ -1560,6 +1561,10 @@ class CopilotClient:
             disabled_skills: Skills to disable.
             infinite_sessions: Infinite session configuration.
             on_event: Callback for session events.
+            continue_pending_work: When True, instructs the runtime to continue any
+                tool calls or permission prompts that were still pending when the
+                session was last suspended. When False (the default), the runtime
+                treats pending work as interrupted on resume.
 
         Returns:
             A :class:`CopilotSession` instance for the resumed session.
@@ -1666,6 +1671,9 @@ class CopilotClient:
             payload["configDir"] = config_dir
         if enable_config_discovery is not None:
             payload["enableConfigDiscovery"] = enable_config_discovery
+
+        if continue_pending_work is not None:
+            payload["continuePendingWork"] = continue_pending_work
 
         # TODO: disable_resume is not a keyword arg yet; keeping for future use
         if mcp_servers:

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -280,6 +280,60 @@ class DiscoveredMCPServerType(Enum):
     SSE = "sse"
     STDIO = "stdio"
 
+@dataclass
+class EmbeddedBlobResourceContents:
+    blob: str
+    """Base64-encoded binary content of the resource"""
+
+    uri: str
+    """URI identifying the resource"""
+
+    mime_type: str | None = None
+    """MIME type of the blob content"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EmbeddedBlobResourceContents':
+        assert isinstance(obj, dict)
+        blob = from_str(obj.get("blob"))
+        uri = from_str(obj.get("uri"))
+        mime_type = from_union([from_str, from_none], obj.get("mimeType"))
+        return EmbeddedBlobResourceContents(blob, uri, mime_type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["blob"] = from_str(self.blob)
+        result["uri"] = from_str(self.uri)
+        if self.mime_type is not None:
+            result["mimeType"] = from_union([from_str, from_none], self.mime_type)
+        return result
+
+@dataclass
+class EmbeddedTextResourceContents:
+    text: str
+    """Text content of the resource"""
+
+    uri: str
+    """URI identifying the resource"""
+
+    mime_type: str | None = None
+    """MIME type of the text content"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'EmbeddedTextResourceContents':
+        assert isinstance(obj, dict)
+        text = from_str(obj.get("text"))
+        uri = from_str(obj.get("uri"))
+        mime_type = from_union([from_str, from_none], obj.get("mimeType"))
+        return EmbeddedTextResourceContents(text, uri, mime_type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["text"] = from_str(self.text)
+        result["uri"] = from_str(self.uri)
+        if self.mime_type is not None:
+            result["mimeType"] = from_union([from_str, from_none], self.mime_type)
+        return result
+
 class ExtensionSource(Enum):
     """Discovery source: project (.github/extensions/) or user (~/.copilot/extensions/)"""
 
@@ -328,6 +382,76 @@ class ExtensionsEnableRequest:
         result["id"] = from_str(self.id)
         return result
 
+class ExternalToolTextResultForLlmContentResourceLinkIconTheme(Enum):
+    """Theme variant this icon is intended for"""
+
+    DARK = "dark"
+    LIGHT = "light"
+
+@dataclass
+class ExternalToolTextResultForLlmContentResourceDetails:
+    """The embedded resource contents, either text or base64-encoded binary"""
+
+    uri: str
+    """URI identifying the resource"""
+
+    mime_type: str | None = None
+    """MIME type of the text content
+
+    MIME type of the blob content
+    """
+    text: str | None = None
+    """Text content of the resource"""
+
+    blob: str | None = None
+    """Base64-encoded binary content of the resource"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContentResourceDetails':
+        assert isinstance(obj, dict)
+        uri = from_str(obj.get("uri"))
+        mime_type = from_union([from_str, from_none], obj.get("mimeType"))
+        text = from_union([from_str, from_none], obj.get("text"))
+        blob = from_union([from_str, from_none], obj.get("blob"))
+        return ExternalToolTextResultForLlmContentResourceDetails(uri, mime_type, text, blob)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["uri"] = from_str(self.uri)
+        if self.mime_type is not None:
+            result["mimeType"] = from_union([from_str, from_none], self.mime_type)
+        if self.text is not None:
+            result["text"] = from_union([from_str, from_none], self.text)
+        if self.blob is not None:
+            result["blob"] = from_union([from_str, from_none], self.blob)
+        return result
+
+class ExternalToolTextResultForLlmContentType(Enum):
+    AUDIO = "audio"
+    IMAGE = "image"
+    RESOURCE = "resource"
+    RESOURCE_LINK = "resource_link"
+    TERMINAL = "terminal"
+    TEXT = "text"
+
+class ExternalToolTextResultForLlmContentAudioType(Enum):
+    AUDIO = "audio"
+
+class ExternalToolTextResultForLlmContentImageType(Enum):
+    IMAGE = "image"
+
+class ExternalToolTextResultForLlmContentResourceType(Enum):
+    RESOURCE = "resource"
+
+class ExternalToolTextResultForLlmContentResourceLinkType(Enum):
+    RESOURCE_LINK = "resource_link"
+
+class ExternalToolTextResultForLlmContentTerminalType(Enum):
+    TERMINAL = "terminal"
+
+class ExternalToolTextResultForLlmContentTextType(Enum):
+    TEXT = "text"
+
 class FilterMappingString(Enum):
     HIDDEN_CHARACTERS = "hidden_characters"
     MARKDOWN = "markdown"
@@ -369,15 +493,15 @@ class FleetStartResult:
         return result
 
 @dataclass
-class HandleToolCallResult:
+class HandlePendingToolCallResult:
     success: bool
     """Whether the tool call result was handled successfully"""
 
     @staticmethod
-    def from_dict(obj: Any) -> 'HandleToolCallResult':
+    def from_dict(obj: Any) -> 'HandlePendingToolCallResult':
         assert isinstance(obj, dict)
         success = from_bool(obj.get("success"))
-        return HandleToolCallResult(success)
+        return HandlePendingToolCallResult(success)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -934,6 +1058,7 @@ class PermissionDecisionKind(Enum):
     APPROVE_FOR_LOCATION = "approve-for-location"
     APPROVE_FOR_SESSION = "approve-for-session"
     APPROVE_ONCE = "approve-once"
+    APPROVE_PERMANENTLY = "approve-permanently"
     REJECT = "reject"
     USER_NOT_AVAILABLE = "user-not-available"
 
@@ -966,6 +1091,9 @@ class PermissionDecisionApproveForSessionKind(Enum):
 
 class PermissionDecisionApproveOnceKind(Enum):
     APPROVE_ONCE = "approve-once"
+
+class PermissionDecisionApprovePermanentlyKind(Enum):
+    APPROVE_PERMANENTLY = "approve-permanently"
 
 class PermissionDecisionRejectKind(Enum):
     REJECT = "reject"
@@ -1983,40 +2111,6 @@ class Tool:
         return result
 
 @dataclass
-class ToolCallResult:
-    text_result_for_llm: str
-    """Text result to send back to the LLM"""
-
-    error: str | None = None
-    """Error message if the tool call failed"""
-
-    result_type: str | None = None
-    """Type of the tool result"""
-
-    tool_telemetry: dict[str, Any] | None = None
-    """Telemetry data from tool execution"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ToolCallResult':
-        assert isinstance(obj, dict)
-        text_result_for_llm = from_str(obj.get("textResultForLlm"))
-        error = from_union([from_str, from_none], obj.get("error"))
-        result_type = from_union([from_str, from_none], obj.get("resultType"))
-        tool_telemetry = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("toolTelemetry"))
-        return ToolCallResult(text_result_for_llm, error, result_type, tool_telemetry)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["textResultForLlm"] = from_str(self.text_result_for_llm)
-        if self.error is not None:
-            result["error"] = from_union([from_str, from_none], self.error)
-        if self.result_type is not None:
-            result["resultType"] = from_union([from_str, from_none], self.result_type)
-        if self.tool_telemetry is not None:
-            result["toolTelemetry"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.tool_telemetry)
-        return result
-
-@dataclass
 class ToolsListRequest:
     model: str | None = None
     """Optional model ID — when provided, the returned tool list reflects model-specific
@@ -2177,6 +2271,22 @@ class UsageMetricsModelMetricRequests:
         return result
 
 @dataclass
+class UsageMetricsModelMetricTokenDetail:
+    token_count: int
+    """Accumulated token count for this token type"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UsageMetricsModelMetricTokenDetail':
+        assert isinstance(obj, dict)
+        token_count = from_int(obj.get("tokenCount"))
+        return UsageMetricsModelMetricTokenDetail(token_count)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["tokenCount"] = from_int(self.token_count)
+        return result
+
+@dataclass
 class UsageMetricsModelMetricUsage:
     """Token usage metrics for this model"""
 
@@ -2213,6 +2323,22 @@ class UsageMetricsModelMetricUsage:
         result["outputTokens"] = from_int(self.output_tokens)
         if self.reasoning_tokens is not None:
             result["reasoningTokens"] = from_union([from_int, from_none], self.reasoning_tokens)
+        return result
+
+@dataclass
+class UsageMetricsTokenDetail:
+    token_count: int
+    """Accumulated token count for this token type"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'UsageMetricsTokenDetail':
+        assert isinstance(obj, dict)
+        token_count = from_int(obj.get("tokenCount"))
+        return UsageMetricsTokenDetail(token_count)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["tokenCount"] = from_int(self.token_count)
         return result
 
 @dataclass
@@ -2491,6 +2617,179 @@ class Extension:
         result["status"] = to_enum(ExtensionStatus, self.status)
         if self.pid is not None:
             result["pid"] = from_union([from_int, from_none], self.pid)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlmContentResourceLinkIcon:
+    """Icon image for a resource"""
+
+    src: str
+    """URL or path to the icon image"""
+
+    mime_type: str | None = None
+    """MIME type of the icon image"""
+
+    sizes: list[str] | None = None
+    """Available icon sizes (e.g., ['16x16', '32x32'])"""
+
+    theme: ExternalToolTextResultForLlmContentResourceLinkIconTheme | None = None
+    """Theme variant this icon is intended for"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContentResourceLinkIcon':
+        assert isinstance(obj, dict)
+        src = from_str(obj.get("src"))
+        mime_type = from_union([from_str, from_none], obj.get("mimeType"))
+        sizes = from_union([lambda x: from_list(from_str, x), from_none], obj.get("sizes"))
+        theme = from_union([ExternalToolTextResultForLlmContentResourceLinkIconTheme, from_none], obj.get("theme"))
+        return ExternalToolTextResultForLlmContentResourceLinkIcon(src, mime_type, sizes, theme)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["src"] = from_str(self.src)
+        if self.mime_type is not None:
+            result["mimeType"] = from_union([from_str, from_none], self.mime_type)
+        if self.sizes is not None:
+            result["sizes"] = from_union([lambda x: from_list(from_str, x), from_none], self.sizes)
+        if self.theme is not None:
+            result["theme"] = from_union([lambda x: to_enum(ExternalToolTextResultForLlmContentResourceLinkIconTheme, x), from_none], self.theme)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlmContentAudio:
+    """Audio content block with base64-encoded data"""
+
+    data: str
+    """Base64-encoded audio data"""
+
+    mime_type: str
+    """MIME type of the audio (e.g., audio/wav, audio/mpeg)"""
+
+    type: ExternalToolTextResultForLlmContentAudioType
+    """Content block type discriminator"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContentAudio':
+        assert isinstance(obj, dict)
+        data = from_str(obj.get("data"))
+        mime_type = from_str(obj.get("mimeType"))
+        type = ExternalToolTextResultForLlmContentAudioType(obj.get("type"))
+        return ExternalToolTextResultForLlmContentAudio(data, mime_type, type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["data"] = from_str(self.data)
+        result["mimeType"] = from_str(self.mime_type)
+        result["type"] = to_enum(ExternalToolTextResultForLlmContentAudioType, self.type)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlmContentImage:
+    """Image content block with base64-encoded data"""
+
+    data: str
+    """Base64-encoded image data"""
+
+    mime_type: str
+    """MIME type of the image (e.g., image/png, image/jpeg)"""
+
+    type: ExternalToolTextResultForLlmContentImageType
+    """Content block type discriminator"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContentImage':
+        assert isinstance(obj, dict)
+        data = from_str(obj.get("data"))
+        mime_type = from_str(obj.get("mimeType"))
+        type = ExternalToolTextResultForLlmContentImageType(obj.get("type"))
+        return ExternalToolTextResultForLlmContentImage(data, mime_type, type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["data"] = from_str(self.data)
+        result["mimeType"] = from_str(self.mime_type)
+        result["type"] = to_enum(ExternalToolTextResultForLlmContentImageType, self.type)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlmContentResource:
+    """Embedded resource content block with inline text or binary data"""
+
+    resource: ExternalToolTextResultForLlmContentResourceDetails
+    """The embedded resource contents, either text or base64-encoded binary"""
+
+    type: ExternalToolTextResultForLlmContentResourceType
+    """Content block type discriminator"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContentResource':
+        assert isinstance(obj, dict)
+        resource = ExternalToolTextResultForLlmContentResourceDetails.from_dict(obj.get("resource"))
+        type = ExternalToolTextResultForLlmContentResourceType(obj.get("type"))
+        return ExternalToolTextResultForLlmContentResource(resource, type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["resource"] = to_class(ExternalToolTextResultForLlmContentResourceDetails, self.resource)
+        result["type"] = to_enum(ExternalToolTextResultForLlmContentResourceType, self.type)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlmContentTerminal:
+    """Terminal/shell output content block with optional exit code and working directory"""
+
+    text: str
+    """Terminal/shell output text"""
+
+    type: ExternalToolTextResultForLlmContentTerminalType
+    """Content block type discriminator"""
+
+    cwd: str | None = None
+    """Working directory where the command was executed"""
+
+    exit_code: float | None = None
+    """Process exit code, if the command has completed"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContentTerminal':
+        assert isinstance(obj, dict)
+        text = from_str(obj.get("text"))
+        type = ExternalToolTextResultForLlmContentTerminalType(obj.get("type"))
+        cwd = from_union([from_str, from_none], obj.get("cwd"))
+        exit_code = from_union([from_float, from_none], obj.get("exitCode"))
+        return ExternalToolTextResultForLlmContentTerminal(text, type, cwd, exit_code)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["text"] = from_str(self.text)
+        result["type"] = to_enum(ExternalToolTextResultForLlmContentTerminalType, self.type)
+        if self.cwd is not None:
+            result["cwd"] = from_union([from_str, from_none], self.cwd)
+        if self.exit_code is not None:
+            result["exitCode"] = from_union([to_float, from_none], self.exit_code)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlmContentText:
+    """Plain text content block"""
+
+    text: str
+    """The text content"""
+
+    type: ExternalToolTextResultForLlmContentTextType
+    """Content block type discriminator"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContentText':
+        assert isinstance(obj, dict)
+        text = from_str(obj.get("text"))
+        type = ExternalToolTextResultForLlmContentTextType(obj.get("type"))
+        return ExternalToolTextResultForLlmContentText(text, type)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["text"] = from_str(self.text)
+        result["type"] = to_enum(ExternalToolTextResultForLlmContentTextType, self.type)
         return result
 
 # Experimental: this type is part of an experimental API and may change or be removed.
@@ -3252,6 +3551,27 @@ class PermissionDecisionApproveOnce:
         return result
 
 @dataclass
+class PermissionDecisionApprovePermanently:
+    domain: str
+    """The URL domain to approve permanently"""
+
+    kind: PermissionDecisionApprovePermanentlyKind
+    """Approved and persisted across sessions"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'PermissionDecisionApprovePermanently':
+        assert isinstance(obj, dict)
+        domain = from_str(obj.get("domain"))
+        kind = PermissionDecisionApprovePermanentlyKind(obj.get("kind"))
+        return PermissionDecisionApprovePermanently(domain, kind)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["domain"] = from_str(self.domain)
+        result["kind"] = to_enum(PermissionDecisionApprovePermanentlyKind, self.kind)
+        return result
+
+@dataclass
 class PermissionDecisionReject:
     kind: PermissionDecisionRejectKind
     """Denied by the user during an interactive prompt"""
@@ -3526,34 +3846,6 @@ class ToolList:
         return result
 
 @dataclass
-class ToolsHandlePendingToolCallRequest:
-    request_id: str
-    """Request ID of the pending tool call"""
-
-    error: str | None = None
-    """Error message if the tool call failed"""
-
-    result: ToolCallResult | str | None = None
-    """Tool call result (string or expanded result object)"""
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'ToolsHandlePendingToolCallRequest':
-        assert isinstance(obj, dict)
-        request_id = from_str(obj.get("requestId"))
-        error = from_union([from_str, from_none], obj.get("error"))
-        result = from_union([ToolCallResult.from_dict, from_str, from_none], obj.get("result"))
-        return ToolsHandlePendingToolCallRequest(request_id, error, result)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["requestId"] = from_str(self.request_id)
-        if self.error is not None:
-            result["error"] = from_union([from_str, from_none], self.error)
-        if self.result is not None:
-            result["result"] = from_union([lambda x: to_class(ToolCallResult, x), from_str, from_none], self.result)
-        return result
-
-@dataclass
 class UIElicitationArrayAnyOfFieldItems:
     any_of: list[UIElicitationArrayAnyOfFieldItemsAnyOf]
 
@@ -3807,17 +4099,29 @@ class UsageMetricsModelMetric:
     usage: UsageMetricsModelMetricUsage
     """Token usage metrics for this model"""
 
+    token_details: dict[str, UsageMetricsModelMetricTokenDetail] | None = None
+    """Token count details per type"""
+
+    total_nano_aiu: int | None = None
+    """Accumulated nano-AI units cost for this model"""
+
     @staticmethod
     def from_dict(obj: Any) -> 'UsageMetricsModelMetric':
         assert isinstance(obj, dict)
         requests = UsageMetricsModelMetricRequests.from_dict(obj.get("requests"))
         usage = UsageMetricsModelMetricUsage.from_dict(obj.get("usage"))
-        return UsageMetricsModelMetric(requests, usage)
+        token_details = from_union([lambda x: from_dict(UsageMetricsModelMetricTokenDetail.from_dict, x), from_none], obj.get("tokenDetails"))
+        total_nano_aiu = from_union([from_int, from_none], obj.get("totalNanoAiu"))
+        return UsageMetricsModelMetric(requests, usage, token_details, total_nano_aiu)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["requests"] = to_class(UsageMetricsModelMetricRequests, self.requests)
         result["usage"] = to_class(UsageMetricsModelMetricUsage, self.usage)
+        if self.token_details is not None:
+            result["tokenDetails"] = from_union([lambda x: from_dict(lambda x: to_class(UsageMetricsModelMetricTokenDetail, x), x), from_none], self.token_details)
+        if self.total_nano_aiu is not None:
+            result["totalNanoAiu"] = from_union([from_int, from_none], self.total_nano_aiu)
         return result
 
 @dataclass
@@ -3934,6 +4238,175 @@ class ExtensionList:
     def to_dict(self) -> dict:
         result: dict = {}
         result["extensions"] = from_list(lambda x: to_class(Extension, x), self.extensions)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlmContent:
+    """A content block within a tool result, which may be text, terminal output, image, audio,
+    or a resource
+
+    Plain text content block
+
+    Terminal/shell output content block with optional exit code and working directory
+
+    Image content block with base64-encoded data
+
+    Audio content block with base64-encoded data
+
+    Resource link content block referencing an external resource
+
+    Embedded resource content block with inline text or binary data
+    """
+    type: ExternalToolTextResultForLlmContentType
+    """Content block type discriminator"""
+
+    text: str | None = None
+    """The text content
+
+    Terminal/shell output text
+    """
+    cwd: str | None = None
+    """Working directory where the command was executed"""
+
+    exit_code: float | None = None
+    """Process exit code, if the command has completed"""
+
+    data: str | None = None
+    """Base64-encoded image data
+
+    Base64-encoded audio data
+    """
+    mime_type: str | None = None
+    """MIME type of the image (e.g., image/png, image/jpeg)
+
+    MIME type of the audio (e.g., audio/wav, audio/mpeg)
+
+    MIME type of the resource content
+    """
+    description: str | None = None
+    """Human-readable description of the resource"""
+
+    icons: list[ExternalToolTextResultForLlmContentResourceLinkIcon] | None = None
+    """Icons associated with this resource"""
+
+    name: str | None = None
+    """Resource name identifier"""
+
+    size: float | None = None
+    """Size of the resource in bytes"""
+
+    title: str | None = None
+    """Human-readable display title for the resource"""
+
+    uri: str | None = None
+    """URI identifying the resource"""
+
+    resource: ExternalToolTextResultForLlmContentResourceDetails | None = None
+    """The embedded resource contents, either text or base64-encoded binary"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContent':
+        assert isinstance(obj, dict)
+        type = ExternalToolTextResultForLlmContentType(obj.get("type"))
+        text = from_union([from_str, from_none], obj.get("text"))
+        cwd = from_union([from_str, from_none], obj.get("cwd"))
+        exit_code = from_union([from_float, from_none], obj.get("exitCode"))
+        data = from_union([from_str, from_none], obj.get("data"))
+        mime_type = from_union([from_str, from_none], obj.get("mimeType"))
+        description = from_union([from_str, from_none], obj.get("description"))
+        icons = from_union([lambda x: from_list(ExternalToolTextResultForLlmContentResourceLinkIcon.from_dict, x), from_none], obj.get("icons"))
+        name = from_union([from_str, from_none], obj.get("name"))
+        size = from_union([from_float, from_none], obj.get("size"))
+        title = from_union([from_str, from_none], obj.get("title"))
+        uri = from_union([from_str, from_none], obj.get("uri"))
+        resource = from_union([ExternalToolTextResultForLlmContentResourceDetails.from_dict, from_none], obj.get("resource"))
+        return ExternalToolTextResultForLlmContent(type, text, cwd, exit_code, data, mime_type, description, icons, name, size, title, uri, resource)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["type"] = to_enum(ExternalToolTextResultForLlmContentType, self.type)
+        if self.text is not None:
+            result["text"] = from_union([from_str, from_none], self.text)
+        if self.cwd is not None:
+            result["cwd"] = from_union([from_str, from_none], self.cwd)
+        if self.exit_code is not None:
+            result["exitCode"] = from_union([to_float, from_none], self.exit_code)
+        if self.data is not None:
+            result["data"] = from_union([from_str, from_none], self.data)
+        if self.mime_type is not None:
+            result["mimeType"] = from_union([from_str, from_none], self.mime_type)
+        if self.description is not None:
+            result["description"] = from_union([from_str, from_none], self.description)
+        if self.icons is not None:
+            result["icons"] = from_union([lambda x: from_list(lambda x: to_class(ExternalToolTextResultForLlmContentResourceLinkIcon, x), x), from_none], self.icons)
+        if self.name is not None:
+            result["name"] = from_union([from_str, from_none], self.name)
+        if self.size is not None:
+            result["size"] = from_union([to_float, from_none], self.size)
+        if self.title is not None:
+            result["title"] = from_union([from_str, from_none], self.title)
+        if self.uri is not None:
+            result["uri"] = from_union([from_str, from_none], self.uri)
+        if self.resource is not None:
+            result["resource"] = from_union([lambda x: to_class(ExternalToolTextResultForLlmContentResourceDetails, x), from_none], self.resource)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlmContentResourceLink:
+    """Resource link content block referencing an external resource"""
+
+    name: str
+    """Resource name identifier"""
+
+    type: ExternalToolTextResultForLlmContentResourceLinkType
+    """Content block type discriminator"""
+
+    uri: str
+    """URI identifying the resource"""
+
+    description: str | None = None
+    """Human-readable description of the resource"""
+
+    icons: list[ExternalToolTextResultForLlmContentResourceLinkIcon] | None = None
+    """Icons associated with this resource"""
+
+    mime_type: str | None = None
+    """MIME type of the resource content"""
+
+    size: float | None = None
+    """Size of the resource in bytes"""
+
+    title: str | None = None
+    """Human-readable display title for the resource"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlmContentResourceLink':
+        assert isinstance(obj, dict)
+        name = from_str(obj.get("name"))
+        type = ExternalToolTextResultForLlmContentResourceLinkType(obj.get("type"))
+        uri = from_str(obj.get("uri"))
+        description = from_union([from_str, from_none], obj.get("description"))
+        icons = from_union([lambda x: from_list(ExternalToolTextResultForLlmContentResourceLinkIcon.from_dict, x), from_none], obj.get("icons"))
+        mime_type = from_union([from_str, from_none], obj.get("mimeType"))
+        size = from_union([from_float, from_none], obj.get("size"))
+        title = from_union([from_str, from_none], obj.get("title"))
+        return ExternalToolTextResultForLlmContentResourceLink(name, type, uri, description, icons, mime_type, size, title)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["name"] = from_str(self.name)
+        result["type"] = to_enum(ExternalToolTextResultForLlmContentResourceLinkType, self.type)
+        result["uri"] = from_str(self.uri)
+        if self.description is not None:
+            result["description"] = from_union([from_str, from_none], self.description)
+        if self.icons is not None:
+            result["icons"] = from_union([lambda x: from_list(lambda x: to_class(ExternalToolTextResultForLlmContentResourceLinkIcon, x), x), from_none], self.icons)
+        if self.mime_type is not None:
+            result["mimeType"] = from_union([from_str, from_none], self.mime_type)
+        if self.size is not None:
+            result["size"] = from_union([to_float, from_none], self.size)
+        if self.title is not None:
+            result["title"] = from_union([from_str, from_none], self.title)
         return result
 
 @dataclass
@@ -4060,6 +4533,8 @@ class PermissionDecision:
 
     Approved and persisted for this project location
 
+    Approved and persisted across sessions
+
     Denied by the user during an interactive prompt
 
     Denied because user confirmation was unavailable
@@ -4068,6 +4543,11 @@ class PermissionDecision:
     """The approval to add as a session-scoped rule
 
     The approval to persist for this location
+    """
+    domain: str | None = None
+    """The URL domain to approve for this session
+
+    The URL domain to approve permanently
     """
     location_key: str | None = None
     """The location key (git root or cwd) to persist the approval to"""
@@ -4080,15 +4560,18 @@ class PermissionDecision:
         assert isinstance(obj, dict)
         kind = PermissionDecisionKind(obj.get("kind"))
         approval = from_union([PermissionDecisionApproveForIonApproval.from_dict, from_none], obj.get("approval"))
+        domain = from_union([from_str, from_none], obj.get("domain"))
         location_key = from_union([from_str, from_none], obj.get("locationKey"))
         feedback = from_union([from_str, from_none], obj.get("feedback"))
-        return PermissionDecision(kind, approval, location_key, feedback)
+        return PermissionDecision(kind, approval, domain, location_key, feedback)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["kind"] = to_enum(PermissionDecisionKind, self.kind)
         if self.approval is not None:
             result["approval"] = from_union([lambda x: to_class(PermissionDecisionApproveForIonApproval, x), from_none], self.approval)
+        if self.domain is not None:
+            result["domain"] = from_union([from_str, from_none], self.domain)
         if self.location_key is not None:
             result["locationKey"] = from_union([from_str, from_none], self.location_key)
         if self.feedback is not None:
@@ -4123,23 +4606,30 @@ class PermissionDecisionApproveForLocation:
 
 @dataclass
 class PermissionDecisionApproveForSession:
-    approval: PermissionDecisionApproveForSessionApproval
-    """The approval to add as a session-scoped rule"""
-
     kind: PermissionDecisionApproveForSessionKind
     """Approved and remembered for the rest of the session"""
+
+    approval: PermissionDecisionApproveForSessionApproval | None = None
+    """The approval to add as a session-scoped rule"""
+
+    domain: str | None = None
+    """The URL domain to approve for this session"""
 
     @staticmethod
     def from_dict(obj: Any) -> 'PermissionDecisionApproveForSession':
         assert isinstance(obj, dict)
-        approval = PermissionDecisionApproveForSessionApproval.from_dict(obj.get("approval"))
         kind = PermissionDecisionApproveForSessionKind(obj.get("kind"))
-        return PermissionDecisionApproveForSession(approval, kind)
+        approval = from_union([PermissionDecisionApproveForSessionApproval.from_dict, from_none], obj.get("approval"))
+        domain = from_union([from_str, from_none], obj.get("domain"))
+        return PermissionDecisionApproveForSession(kind, approval, domain)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["approval"] = to_class(PermissionDecisionApproveForSessionApproval, self.approval)
         result["kind"] = to_enum(PermissionDecisionApproveForSessionKind, self.kind)
+        if self.approval is not None:
+            result["approval"] = from_union([lambda x: to_class(PermissionDecisionApproveForSessionApproval, x), from_none], self.approval)
+        if self.domain is not None:
+            result["domain"] = from_union([from_str, from_none], self.domain)
         return result
 
 @dataclass
@@ -4449,6 +4939,12 @@ class UsageGetMetricsResult:
     current_model: str | None = None
     """Currently active model identifier"""
 
+    token_details: dict[str, UsageMetricsTokenDetail] | None = None
+    """Session-wide per-token-type accumulated token counts"""
+
+    total_nano_aiu: int | None = None
+    """Session-wide accumulated nano-AI units cost"""
+
     @staticmethod
     def from_dict(obj: Any) -> 'UsageGetMetricsResult':
         assert isinstance(obj, dict)
@@ -4461,7 +4957,9 @@ class UsageGetMetricsResult:
         total_premium_request_cost = from_float(obj.get("totalPremiumRequestCost"))
         total_user_requests = from_int(obj.get("totalUserRequests"))
         current_model = from_union([from_str, from_none], obj.get("currentModel"))
-        return UsageGetMetricsResult(code_changes, last_call_input_tokens, last_call_output_tokens, model_metrics, session_start_time, total_api_duration_ms, total_premium_request_cost, total_user_requests, current_model)
+        token_details = from_union([lambda x: from_dict(UsageMetricsTokenDetail.from_dict, x), from_none], obj.get("tokenDetails"))
+        total_nano_aiu = from_union([from_int, from_none], obj.get("totalNanoAiu"))
+        return UsageGetMetricsResult(code_changes, last_call_input_tokens, last_call_output_tokens, model_metrics, session_start_time, total_api_duration_ms, total_premium_request_cost, total_user_requests, current_model, token_details, total_nano_aiu)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -4475,6 +4973,10 @@ class UsageGetMetricsResult:
         result["totalUserRequests"] = from_int(self.total_user_requests)
         if self.current_model is not None:
             result["currentModel"] = from_union([from_str, from_none], self.current_model)
+        if self.token_details is not None:
+            result["tokenDetails"] = from_union([lambda x: from_dict(lambda x: to_class(UsageMetricsTokenDetail, x), x), from_none], self.token_details)
+        if self.total_nano_aiu is not None:
+            result["totalNanoAiu"] = from_union([from_int, from_none], self.total_nano_aiu)
         return result
 
 @dataclass
@@ -4491,6 +4993,55 @@ class WorkspacesGetWorkspaceResult:
     def to_dict(self) -> dict:
         result: dict = {}
         result["workspace"] = from_union([lambda x: to_class(Workspace, x), from_none], self.workspace)
+        return result
+
+@dataclass
+class ExternalToolTextResultForLlm:
+    """Expanded external tool result payload"""
+
+    text_result_for_llm: str
+    """Text result returned to the model"""
+
+    contents: list[ExternalToolTextResultForLlmContent] | None = None
+    """Structured content blocks from the tool"""
+
+    error: str | None = None
+    """Optional error message for failed executions"""
+
+    result_type: str | None = None
+    """Execution outcome classification. Optional for back-compat; normalized to 'success' (or
+    'failure' when error is present) when missing or unrecognized.
+    """
+    session_log: str | None = None
+    """Detailed log content for timeline display"""
+
+    tool_telemetry: dict[str, Any] | None = None
+    """Optional tool-specific telemetry"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'ExternalToolTextResultForLlm':
+        assert isinstance(obj, dict)
+        text_result_for_llm = from_str(obj.get("textResultForLlm"))
+        contents = from_union([lambda x: from_list(ExternalToolTextResultForLlmContent.from_dict, x), from_none], obj.get("contents"))
+        error = from_union([from_str, from_none], obj.get("error"))
+        result_type = from_union([from_str, from_none], obj.get("resultType"))
+        session_log = from_union([from_str, from_none], obj.get("sessionLog"))
+        tool_telemetry = from_union([lambda x: from_dict(lambda x: x, x), from_none], obj.get("toolTelemetry"))
+        return ExternalToolTextResultForLlm(text_result_for_llm, contents, error, result_type, session_log, tool_telemetry)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["textResultForLlm"] = from_str(self.text_result_for_llm)
+        if self.contents is not None:
+            result["contents"] = from_union([lambda x: from_list(lambda x: to_class(ExternalToolTextResultForLlmContent, x), x), from_none], self.contents)
+        if self.error is not None:
+            result["error"] = from_union([from_str, from_none], self.error)
+        if self.result_type is not None:
+            result["resultType"] = from_union([from_str, from_none], self.result_type)
+        if self.session_log is not None:
+            result["sessionLog"] = from_union([from_str, from_none], self.session_log)
+        if self.tool_telemetry is not None:
+            result["toolTelemetry"] = from_union([lambda x: from_dict(lambda x: x, x), from_none], self.tool_telemetry)
         return result
 
 @dataclass
@@ -4540,6 +5091,34 @@ class UIElicitationSchema:
         result["type"] = to_enum(UIElicitationSchemaType, self.type)
         if self.required is not None:
             result["required"] = from_union([lambda x: from_list(from_str, x), from_none], self.required)
+        return result
+
+@dataclass
+class HandlePendingToolCallRequest:
+    request_id: str
+    """Request ID of the pending tool call"""
+
+    error: str | None = None
+    """Error message if the tool call failed"""
+
+    result: ExternalToolTextResultForLlm | str | None = None
+    """Tool call result (string or expanded result object)"""
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'HandlePendingToolCallRequest':
+        assert isinstance(obj, dict)
+        request_id = from_str(obj.get("requestId"))
+        error = from_union([from_str, from_none], obj.get("error"))
+        result = from_union([ExternalToolTextResultForLlm.from_dict, from_str, from_none], obj.get("result"))
+        return HandlePendingToolCallRequest(request_id, error, result)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["requestId"] = from_str(self.request_id)
+        if self.error is not None:
+            result["error"] = from_union([from_str, from_none], self.error)
+        if self.result is not None:
+            result["result"] = from_union([lambda x: to_class(ExternalToolTextResultForLlm, x), from_str, from_none], self.result)
         return result
 
 @dataclass
@@ -4975,18 +5554,33 @@ class RPC:
     discovered_mcp_server: DiscoveredMCPServer
     discovered_mcp_server_source: MCPServerSource
     discovered_mcp_server_type: DiscoveredMCPServerType
+    embedded_blob_resource_contents: EmbeddedBlobResourceContents
+    embedded_text_resource_contents: EmbeddedTextResourceContents
     extension: Extension
     extension_list: ExtensionList
     extensions_disable_request: ExtensionsDisableRequest
     extensions_enable_request: ExtensionsEnableRequest
     extension_source: ExtensionSource
     extension_status: ExtensionStatus
+    external_tool_result: ExternalToolTextResultForLlm | str
+    external_tool_text_result_for_llm: ExternalToolTextResultForLlm
+    external_tool_text_result_for_llm_content: ExternalToolTextResultForLlmContent
+    external_tool_text_result_for_llm_content_audio: ExternalToolTextResultForLlmContentAudio
+    external_tool_text_result_for_llm_content_image: ExternalToolTextResultForLlmContentImage
+    external_tool_text_result_for_llm_content_resource: ExternalToolTextResultForLlmContentResource
+    external_tool_text_result_for_llm_content_resource_details: ExternalToolTextResultForLlmContentResourceDetails
+    external_tool_text_result_for_llm_content_resource_link: ExternalToolTextResultForLlmContentResourceLink
+    external_tool_text_result_for_llm_content_resource_link_icon: ExternalToolTextResultForLlmContentResourceLinkIcon
+    external_tool_text_result_for_llm_content_resource_link_icon_theme: ExternalToolTextResultForLlmContentResourceLinkIconTheme
+    external_tool_text_result_for_llm_content_terminal: ExternalToolTextResultForLlmContentTerminal
+    external_tool_text_result_for_llm_content_text: ExternalToolTextResultForLlmContentText
     filter_mapping: dict[str, FilterMappingString] | FilterMappingString
     filter_mapping_string: FilterMappingString
     filter_mapping_value: FilterMappingString
     fleet_start_request: FleetStartRequest
     fleet_start_result: FleetStartResult
-    handle_tool_call_result: HandleToolCallResult
+    handle_pending_tool_call_request: HandlePendingToolCallRequest
+    handle_pending_tool_call_result: HandlePendingToolCallResult
     history_compact_context_window: HistoryCompactContextWindow
     history_compact_result: HistoryCompactResult
     history_truncate_request: HistoryTruncateRequest
@@ -5056,6 +5650,7 @@ class RPC:
     permission_decision_approve_for_session_approval_read: PermissionDecisionApproveForSessionApprovalRead
     permission_decision_approve_for_session_approval_write: PermissionDecisionApproveForSessionApprovalWrite
     permission_decision_approve_once: PermissionDecisionApproveOnce
+    permission_decision_approve_permanently: PermissionDecisionApprovePermanently
     permission_decision_reject: PermissionDecisionReject
     permission_decision_request: PermissionDecisionRequest
     permission_decision_user_not_available: PermissionDecisionUserNotAvailable
@@ -5128,10 +5723,7 @@ class RPC:
     tasks_start_agent_request: TasksStartAgentRequest
     tasks_start_agent_result: TasksStartAgentResult
     tool: Tool
-    tool_call_result: ToolCallResult
     tool_list: ToolList
-    tools_handle_pending_tool_call: ToolCallResult | str
-    tools_handle_pending_tool_call_request: ToolsHandlePendingToolCallRequest
     tools_list_request: ToolsListRequest
     ui_elicitation_array_any_of_field: UIElicitationArrayAnyOfField
     ui_elicitation_array_any_of_field_items: UIElicitationArrayAnyOfFieldItems
@@ -5159,7 +5751,9 @@ class RPC:
     usage_metrics_code_changes: UsageMetricsCodeChanges
     usage_metrics_model_metric: UsageMetricsModelMetric
     usage_metrics_model_metric_requests: UsageMetricsModelMetricRequests
+    usage_metrics_model_metric_token_detail: UsageMetricsModelMetricTokenDetail
     usage_metrics_model_metric_usage: UsageMetricsModelMetricUsage
+    usage_metrics_token_detail: UsageMetricsTokenDetail
     workspaces_create_file_request: WorkspacesCreateFileRequest
     workspaces_get_workspace_result: WorkspacesGetWorkspaceResult
     workspaces_list_files_result: WorkspacesListFilesResult
@@ -5185,18 +5779,33 @@ class RPC:
         discovered_mcp_server = DiscoveredMCPServer.from_dict(obj.get("DiscoveredMcpServer"))
         discovered_mcp_server_source = MCPServerSource(obj.get("DiscoveredMcpServerSource"))
         discovered_mcp_server_type = DiscoveredMCPServerType(obj.get("DiscoveredMcpServerType"))
+        embedded_blob_resource_contents = EmbeddedBlobResourceContents.from_dict(obj.get("EmbeddedBlobResourceContents"))
+        embedded_text_resource_contents = EmbeddedTextResourceContents.from_dict(obj.get("EmbeddedTextResourceContents"))
         extension = Extension.from_dict(obj.get("Extension"))
         extension_list = ExtensionList.from_dict(obj.get("ExtensionList"))
         extensions_disable_request = ExtensionsDisableRequest.from_dict(obj.get("ExtensionsDisableRequest"))
         extensions_enable_request = ExtensionsEnableRequest.from_dict(obj.get("ExtensionsEnableRequest"))
         extension_source = ExtensionSource(obj.get("ExtensionSource"))
         extension_status = ExtensionStatus(obj.get("ExtensionStatus"))
+        external_tool_result = from_union([ExternalToolTextResultForLlm.from_dict, from_str], obj.get("ExternalToolResult"))
+        external_tool_text_result_for_llm = ExternalToolTextResultForLlm.from_dict(obj.get("ExternalToolTextResultForLlm"))
+        external_tool_text_result_for_llm_content = ExternalToolTextResultForLlmContent.from_dict(obj.get("ExternalToolTextResultForLlmContent"))
+        external_tool_text_result_for_llm_content_audio = ExternalToolTextResultForLlmContentAudio.from_dict(obj.get("ExternalToolTextResultForLlmContentAudio"))
+        external_tool_text_result_for_llm_content_image = ExternalToolTextResultForLlmContentImage.from_dict(obj.get("ExternalToolTextResultForLlmContentImage"))
+        external_tool_text_result_for_llm_content_resource = ExternalToolTextResultForLlmContentResource.from_dict(obj.get("ExternalToolTextResultForLlmContentResource"))
+        external_tool_text_result_for_llm_content_resource_details = ExternalToolTextResultForLlmContentResourceDetails.from_dict(obj.get("ExternalToolTextResultForLlmContentResourceDetails"))
+        external_tool_text_result_for_llm_content_resource_link = ExternalToolTextResultForLlmContentResourceLink.from_dict(obj.get("ExternalToolTextResultForLlmContentResourceLink"))
+        external_tool_text_result_for_llm_content_resource_link_icon = ExternalToolTextResultForLlmContentResourceLinkIcon.from_dict(obj.get("ExternalToolTextResultForLlmContentResourceLinkIcon"))
+        external_tool_text_result_for_llm_content_resource_link_icon_theme = ExternalToolTextResultForLlmContentResourceLinkIconTheme(obj.get("ExternalToolTextResultForLlmContentResourceLinkIconTheme"))
+        external_tool_text_result_for_llm_content_terminal = ExternalToolTextResultForLlmContentTerminal.from_dict(obj.get("ExternalToolTextResultForLlmContentTerminal"))
+        external_tool_text_result_for_llm_content_text = ExternalToolTextResultForLlmContentText.from_dict(obj.get("ExternalToolTextResultForLlmContentText"))
         filter_mapping = from_union([lambda x: from_dict(FilterMappingString, x), FilterMappingString], obj.get("FilterMapping"))
         filter_mapping_string = FilterMappingString(obj.get("FilterMappingString"))
         filter_mapping_value = FilterMappingString(obj.get("FilterMappingValue"))
         fleet_start_request = FleetStartRequest.from_dict(obj.get("FleetStartRequest"))
         fleet_start_result = FleetStartResult.from_dict(obj.get("FleetStartResult"))
-        handle_tool_call_result = HandleToolCallResult.from_dict(obj.get("HandleToolCallResult"))
+        handle_pending_tool_call_request = HandlePendingToolCallRequest.from_dict(obj.get("HandlePendingToolCallRequest"))
+        handle_pending_tool_call_result = HandlePendingToolCallResult.from_dict(obj.get("HandlePendingToolCallResult"))
         history_compact_context_window = HistoryCompactContextWindow.from_dict(obj.get("HistoryCompactContextWindow"))
         history_compact_result = HistoryCompactResult.from_dict(obj.get("HistoryCompactResult"))
         history_truncate_request = HistoryTruncateRequest.from_dict(obj.get("HistoryTruncateRequest"))
@@ -5266,6 +5875,7 @@ class RPC:
         permission_decision_approve_for_session_approval_read = PermissionDecisionApproveForSessionApprovalRead.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalRead"))
         permission_decision_approve_for_session_approval_write = PermissionDecisionApproveForSessionApprovalWrite.from_dict(obj.get("PermissionDecisionApproveForSessionApprovalWrite"))
         permission_decision_approve_once = PermissionDecisionApproveOnce.from_dict(obj.get("PermissionDecisionApproveOnce"))
+        permission_decision_approve_permanently = PermissionDecisionApprovePermanently.from_dict(obj.get("PermissionDecisionApprovePermanently"))
         permission_decision_reject = PermissionDecisionReject.from_dict(obj.get("PermissionDecisionReject"))
         permission_decision_request = PermissionDecisionRequest.from_dict(obj.get("PermissionDecisionRequest"))
         permission_decision_user_not_available = PermissionDecisionUserNotAvailable.from_dict(obj.get("PermissionDecisionUserNotAvailable"))
@@ -5338,10 +5948,7 @@ class RPC:
         tasks_start_agent_request = TasksStartAgentRequest.from_dict(obj.get("TasksStartAgentRequest"))
         tasks_start_agent_result = TasksStartAgentResult.from_dict(obj.get("TasksStartAgentResult"))
         tool = Tool.from_dict(obj.get("Tool"))
-        tool_call_result = ToolCallResult.from_dict(obj.get("ToolCallResult"))
         tool_list = ToolList.from_dict(obj.get("ToolList"))
-        tools_handle_pending_tool_call = from_union([ToolCallResult.from_dict, from_str], obj.get("ToolsHandlePendingToolCall"))
-        tools_handle_pending_tool_call_request = ToolsHandlePendingToolCallRequest.from_dict(obj.get("ToolsHandlePendingToolCallRequest"))
         tools_list_request = ToolsListRequest.from_dict(obj.get("ToolsListRequest"))
         ui_elicitation_array_any_of_field = UIElicitationArrayAnyOfField.from_dict(obj.get("UIElicitationArrayAnyOfField"))
         ui_elicitation_array_any_of_field_items = UIElicitationArrayAnyOfFieldItems.from_dict(obj.get("UIElicitationArrayAnyOfFieldItems"))
@@ -5369,13 +5976,15 @@ class RPC:
         usage_metrics_code_changes = UsageMetricsCodeChanges.from_dict(obj.get("UsageMetricsCodeChanges"))
         usage_metrics_model_metric = UsageMetricsModelMetric.from_dict(obj.get("UsageMetricsModelMetric"))
         usage_metrics_model_metric_requests = UsageMetricsModelMetricRequests.from_dict(obj.get("UsageMetricsModelMetricRequests"))
+        usage_metrics_model_metric_token_detail = UsageMetricsModelMetricTokenDetail.from_dict(obj.get("UsageMetricsModelMetricTokenDetail"))
         usage_metrics_model_metric_usage = UsageMetricsModelMetricUsage.from_dict(obj.get("UsageMetricsModelMetricUsage"))
+        usage_metrics_token_detail = UsageMetricsTokenDetail.from_dict(obj.get("UsageMetricsTokenDetail"))
         workspaces_create_file_request = WorkspacesCreateFileRequest.from_dict(obj.get("WorkspacesCreateFileRequest"))
         workspaces_get_workspace_result = WorkspacesGetWorkspaceResult.from_dict(obj.get("WorkspacesGetWorkspaceResult"))
         workspaces_list_files_result = WorkspacesListFilesResult.from_dict(obj.get("WorkspacesListFilesResult"))
         workspaces_read_file_request = WorkspacesReadFileRequest.from_dict(obj.get("WorkspacesReadFileRequest"))
         workspaces_read_file_result = WorkspacesReadFileResult.from_dict(obj.get("WorkspacesReadFileResult"))
-        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, commands_handle_pending_command_request, commands_handle_pending_command_result, current_model, discovered_mcp_server, discovered_mcp_server_source, discovered_mcp_server_type, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, filter_mapping, filter_mapping_string, filter_mapping_value, fleet_start_request, fleet_start_result, handle_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_type, mcp_server_config_local, mcp_server_config_local_type, mcp_server_list, mcp_server_source, mcp_server_status, model, model_billing, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_policy, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, task_agent_info, task_agent_info_execution_mode, task_agent_info_status, task_info, task_list, tasks_cancel_request, tasks_cancel_result, task_shell_info, task_shell_info_attachment_mode, task_shell_info_execution_mode, task_shell_info_status, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_remove_request, tasks_remove_result, tasks_start_agent_request, tasks_start_agent_result, tool, tool_call_result, tool_list, tools_handle_pending_tool_call, tools_handle_pending_tool_call_request, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_usage, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
+        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, commands_handle_pending_command_request, commands_handle_pending_command_result, current_model, discovered_mcp_server, discovered_mcp_server_source, discovered_mcp_server_type, embedded_blob_resource_contents, embedded_text_resource_contents, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, filter_mapping, filter_mapping_string, filter_mapping_value, fleet_start_request, fleet_start_result, handle_pending_tool_call_request, handle_pending_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_type, mcp_server_config_local, mcp_server_config_local_type, mcp_server_list, mcp_server_source, mcp_server_status, model, model_billing, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_policy, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, task_agent_info, task_agent_info_execution_mode, task_agent_info_status, task_info, task_list, tasks_cancel_request, tasks_cancel_result, task_shell_info, task_shell_info_attachment_mode, task_shell_info_execution_mode, task_shell_info_status, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_remove_request, tasks_remove_result, tasks_start_agent_request, tasks_start_agent_result, tool, tool_list, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -5395,18 +6004,33 @@ class RPC:
         result["DiscoveredMcpServer"] = to_class(DiscoveredMCPServer, self.discovered_mcp_server)
         result["DiscoveredMcpServerSource"] = to_enum(MCPServerSource, self.discovered_mcp_server_source)
         result["DiscoveredMcpServerType"] = to_enum(DiscoveredMCPServerType, self.discovered_mcp_server_type)
+        result["EmbeddedBlobResourceContents"] = to_class(EmbeddedBlobResourceContents, self.embedded_blob_resource_contents)
+        result["EmbeddedTextResourceContents"] = to_class(EmbeddedTextResourceContents, self.embedded_text_resource_contents)
         result["Extension"] = to_class(Extension, self.extension)
         result["ExtensionList"] = to_class(ExtensionList, self.extension_list)
         result["ExtensionsDisableRequest"] = to_class(ExtensionsDisableRequest, self.extensions_disable_request)
         result["ExtensionsEnableRequest"] = to_class(ExtensionsEnableRequest, self.extensions_enable_request)
         result["ExtensionSource"] = to_enum(ExtensionSource, self.extension_source)
         result["ExtensionStatus"] = to_enum(ExtensionStatus, self.extension_status)
+        result["ExternalToolResult"] = from_union([lambda x: to_class(ExternalToolTextResultForLlm, x), from_str], self.external_tool_result)
+        result["ExternalToolTextResultForLlm"] = to_class(ExternalToolTextResultForLlm, self.external_tool_text_result_for_llm)
+        result["ExternalToolTextResultForLlmContent"] = to_class(ExternalToolTextResultForLlmContent, self.external_tool_text_result_for_llm_content)
+        result["ExternalToolTextResultForLlmContentAudio"] = to_class(ExternalToolTextResultForLlmContentAudio, self.external_tool_text_result_for_llm_content_audio)
+        result["ExternalToolTextResultForLlmContentImage"] = to_class(ExternalToolTextResultForLlmContentImage, self.external_tool_text_result_for_llm_content_image)
+        result["ExternalToolTextResultForLlmContentResource"] = to_class(ExternalToolTextResultForLlmContentResource, self.external_tool_text_result_for_llm_content_resource)
+        result["ExternalToolTextResultForLlmContentResourceDetails"] = to_class(ExternalToolTextResultForLlmContentResourceDetails, self.external_tool_text_result_for_llm_content_resource_details)
+        result["ExternalToolTextResultForLlmContentResourceLink"] = to_class(ExternalToolTextResultForLlmContentResourceLink, self.external_tool_text_result_for_llm_content_resource_link)
+        result["ExternalToolTextResultForLlmContentResourceLinkIcon"] = to_class(ExternalToolTextResultForLlmContentResourceLinkIcon, self.external_tool_text_result_for_llm_content_resource_link_icon)
+        result["ExternalToolTextResultForLlmContentResourceLinkIconTheme"] = to_enum(ExternalToolTextResultForLlmContentResourceLinkIconTheme, self.external_tool_text_result_for_llm_content_resource_link_icon_theme)
+        result["ExternalToolTextResultForLlmContentTerminal"] = to_class(ExternalToolTextResultForLlmContentTerminal, self.external_tool_text_result_for_llm_content_terminal)
+        result["ExternalToolTextResultForLlmContentText"] = to_class(ExternalToolTextResultForLlmContentText, self.external_tool_text_result_for_llm_content_text)
         result["FilterMapping"] = from_union([lambda x: from_dict(lambda x: to_enum(FilterMappingString, x), x), lambda x: to_enum(FilterMappingString, x)], self.filter_mapping)
         result["FilterMappingString"] = to_enum(FilterMappingString, self.filter_mapping_string)
         result["FilterMappingValue"] = to_enum(FilterMappingString, self.filter_mapping_value)
         result["FleetStartRequest"] = to_class(FleetStartRequest, self.fleet_start_request)
         result["FleetStartResult"] = to_class(FleetStartResult, self.fleet_start_result)
-        result["HandleToolCallResult"] = to_class(HandleToolCallResult, self.handle_tool_call_result)
+        result["HandlePendingToolCallRequest"] = to_class(HandlePendingToolCallRequest, self.handle_pending_tool_call_request)
+        result["HandlePendingToolCallResult"] = to_class(HandlePendingToolCallResult, self.handle_pending_tool_call_result)
         result["HistoryCompactContextWindow"] = to_class(HistoryCompactContextWindow, self.history_compact_context_window)
         result["HistoryCompactResult"] = to_class(HistoryCompactResult, self.history_compact_result)
         result["HistoryTruncateRequest"] = to_class(HistoryTruncateRequest, self.history_truncate_request)
@@ -5476,6 +6100,7 @@ class RPC:
         result["PermissionDecisionApproveForSessionApprovalRead"] = to_class(PermissionDecisionApproveForSessionApprovalRead, self.permission_decision_approve_for_session_approval_read)
         result["PermissionDecisionApproveForSessionApprovalWrite"] = to_class(PermissionDecisionApproveForSessionApprovalWrite, self.permission_decision_approve_for_session_approval_write)
         result["PermissionDecisionApproveOnce"] = to_class(PermissionDecisionApproveOnce, self.permission_decision_approve_once)
+        result["PermissionDecisionApprovePermanently"] = to_class(PermissionDecisionApprovePermanently, self.permission_decision_approve_permanently)
         result["PermissionDecisionReject"] = to_class(PermissionDecisionReject, self.permission_decision_reject)
         result["PermissionDecisionRequest"] = to_class(PermissionDecisionRequest, self.permission_decision_request)
         result["PermissionDecisionUserNotAvailable"] = to_class(PermissionDecisionUserNotAvailable, self.permission_decision_user_not_available)
@@ -5548,10 +6173,7 @@ class RPC:
         result["TasksStartAgentRequest"] = to_class(TasksStartAgentRequest, self.tasks_start_agent_request)
         result["TasksStartAgentResult"] = to_class(TasksStartAgentResult, self.tasks_start_agent_result)
         result["Tool"] = to_class(Tool, self.tool)
-        result["ToolCallResult"] = to_class(ToolCallResult, self.tool_call_result)
         result["ToolList"] = to_class(ToolList, self.tool_list)
-        result["ToolsHandlePendingToolCall"] = from_union([lambda x: to_class(ToolCallResult, x), from_str], self.tools_handle_pending_tool_call)
-        result["ToolsHandlePendingToolCallRequest"] = to_class(ToolsHandlePendingToolCallRequest, self.tools_handle_pending_tool_call_request)
         result["ToolsListRequest"] = to_class(ToolsListRequest, self.tools_list_request)
         result["UIElicitationArrayAnyOfField"] = to_class(UIElicitationArrayAnyOfField, self.ui_elicitation_array_any_of_field)
         result["UIElicitationArrayAnyOfFieldItems"] = to_class(UIElicitationArrayAnyOfFieldItems, self.ui_elicitation_array_any_of_field_items)
@@ -5579,7 +6201,9 @@ class RPC:
         result["UsageMetricsCodeChanges"] = to_class(UsageMetricsCodeChanges, self.usage_metrics_code_changes)
         result["UsageMetricsModelMetric"] = to_class(UsageMetricsModelMetric, self.usage_metrics_model_metric)
         result["UsageMetricsModelMetricRequests"] = to_class(UsageMetricsModelMetricRequests, self.usage_metrics_model_metric_requests)
+        result["UsageMetricsModelMetricTokenDetail"] = to_class(UsageMetricsModelMetricTokenDetail, self.usage_metrics_model_metric_token_detail)
         result["UsageMetricsModelMetricUsage"] = to_class(UsageMetricsModelMetricUsage, self.usage_metrics_model_metric_usage)
+        result["UsageMetricsTokenDetail"] = to_class(UsageMetricsTokenDetail, self.usage_metrics_token_detail)
         result["WorkspacesCreateFileRequest"] = to_class(WorkspacesCreateFileRequest, self.workspaces_create_file_request)
         result["WorkspacesGetWorkspaceResult"] = to_class(WorkspacesGetWorkspaceResult, self.workspaces_get_workspace_result)
         result["WorkspacesListFilesResult"] = to_class(WorkspacesListFilesResult, self.workspaces_list_files_result)
@@ -6004,10 +6628,10 @@ class ToolsApi:
         self._client = client
         self._session_id = session_id
 
-    async def handle_pending_tool_call(self, params: ToolsHandlePendingToolCallRequest, *, timeout: float | None = None) -> HandleToolCallResult:
+    async def handle_pending_tool_call(self, params: HandlePendingToolCallRequest, *, timeout: float | None = None) -> HandlePendingToolCallResult:
         params_dict: dict[str, Any] = {k: v for k, v in params.to_dict().items() if v is not None}
         params_dict["sessionId"] = self._session_id
-        return HandleToolCallResult.from_dict(await self._client.request("session.tools.handlePendingToolCall", params_dict, **_timeout_kwargs(timeout)))
+        return HandlePendingToolCallResult.from_dict(await self._client.request("session.tools.handlePendingToolCall", params_dict, **_timeout_kwargs(timeout)))
 
 
 class CommandsApi:

--- a/python/copilot/generated/rpc.py
+++ b/python/copilot/generated/rpc.py
@@ -629,6 +629,10 @@ class LogResult:
         result["eventId"] = str(self.event_id)
         return result
 
+class MCPServerConfigHTTPOauthGrantType(Enum):
+    AUTHORIZATION_CODE = "authorization_code"
+    CLIENT_CREDENTIALS = "client_credentials"
+
 class MCPServerConfigType(Enum):
     """Remote transport type. Defaults to "http" when omitted."""
 
@@ -2934,6 +2938,7 @@ class MCPServerConfig:
 
     headers: dict[str, str] | None = None
     oauth_client_id: str | None = None
+    oauth_grant_type: MCPServerConfigHTTPOauthGrantType | None = None
     oauth_public_client: bool | None = None
     url: str | None = None
 
@@ -2951,9 +2956,10 @@ class MCPServerConfig:
         type = from_union([MCPServerConfigType, from_none], obj.get("type"))
         headers = from_union([lambda x: from_dict(from_str, x), from_none], obj.get("headers"))
         oauth_client_id = from_union([from_str, from_none], obj.get("oauthClientId"))
+        oauth_grant_type = from_union([MCPServerConfigHTTPOauthGrantType, from_none], obj.get("oauthGrantType"))
         oauth_public_client = from_union([from_bool, from_none], obj.get("oauthPublicClient"))
         url = from_union([from_str, from_none], obj.get("url"))
-        return MCPServerConfig(args, command, cwd, env, filter_mapping, is_default_server, timeout, tools, type, headers, oauth_client_id, oauth_public_client, url)
+        return MCPServerConfig(args, command, cwd, env, filter_mapping, is_default_server, timeout, tools, type, headers, oauth_client_id, oauth_grant_type, oauth_public_client, url)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -2979,6 +2985,8 @@ class MCPServerConfig:
             result["headers"] = from_union([lambda x: from_dict(from_str, x), from_none], self.headers)
         if self.oauth_client_id is not None:
             result["oauthClientId"] = from_union([from_str, from_none], self.oauth_client_id)
+        if self.oauth_grant_type is not None:
+            result["oauthGrantType"] = from_union([lambda x: to_enum(MCPServerConfigHTTPOauthGrantType, x), from_none], self.oauth_grant_type)
         if self.oauth_public_client is not None:
             result["oauthPublicClient"] = from_union([from_bool, from_none], self.oauth_public_client)
         if self.url is not None:
@@ -3025,6 +3033,7 @@ class MCPServerConfigHTTP:
     headers: dict[str, str] | None = None
     is_default_server: bool | None = None
     oauth_client_id: str | None = None
+    oauth_grant_type: MCPServerConfigHTTPOauthGrantType | None = None
     oauth_public_client: bool | None = None
     timeout: int | None = None
     """Timeout in milliseconds for tool calls to this server."""
@@ -3043,11 +3052,12 @@ class MCPServerConfigHTTP:
         headers = from_union([lambda x: from_dict(from_str, x), from_none], obj.get("headers"))
         is_default_server = from_union([from_bool, from_none], obj.get("isDefaultServer"))
         oauth_client_id = from_union([from_str, from_none], obj.get("oauthClientId"))
+        oauth_grant_type = from_union([MCPServerConfigHTTPOauthGrantType, from_none], obj.get("oauthGrantType"))
         oauth_public_client = from_union([from_bool, from_none], obj.get("oauthPublicClient"))
         timeout = from_union([from_int, from_none], obj.get("timeout"))
         tools = from_union([lambda x: from_list(from_str, x), from_none], obj.get("tools"))
         type = from_union([MCPServerConfigHTTPType, from_none], obj.get("type"))
-        return MCPServerConfigHTTP(url, filter_mapping, headers, is_default_server, oauth_client_id, oauth_public_client, timeout, tools, type)
+        return MCPServerConfigHTTP(url, filter_mapping, headers, is_default_server, oauth_client_id, oauth_grant_type, oauth_public_client, timeout, tools, type)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -3060,6 +3070,8 @@ class MCPServerConfigHTTP:
             result["isDefaultServer"] = from_union([from_bool, from_none], self.is_default_server)
         if self.oauth_client_id is not None:
             result["oauthClientId"] = from_union([from_str, from_none], self.oauth_client_id)
+        if self.oauth_grant_type is not None:
+            result["oauthGrantType"] = from_union([lambda x: to_enum(MCPServerConfigHTTPOauthGrantType, x), from_none], self.oauth_grant_type)
         if self.oauth_public_client is not None:
             result["oauthPublicClient"] = from_union([from_bool, from_none], self.oauth_public_client)
         if self.timeout is not None:
@@ -5606,6 +5618,7 @@ class RPC:
     mcp_server: MCPServer
     mcp_server_config: MCPServerConfig
     mcp_server_config_http: MCPServerConfigHTTP
+    mcp_server_config_http_oauth_grant_type: MCPServerConfigHTTPOauthGrantType
     mcp_server_config_http_type: MCPServerConfigHTTPType
     mcp_server_config_local: MCPServerConfigLocal
     mcp_server_config_local_type: MCPServerConfigLocalType
@@ -5831,6 +5844,7 @@ class RPC:
         mcp_server = MCPServer.from_dict(obj.get("McpServer"))
         mcp_server_config = MCPServerConfig.from_dict(obj.get("McpServerConfig"))
         mcp_server_config_http = MCPServerConfigHTTP.from_dict(obj.get("McpServerConfigHttp"))
+        mcp_server_config_http_oauth_grant_type = MCPServerConfigHTTPOauthGrantType(obj.get("McpServerConfigHttpOauthGrantType"))
         mcp_server_config_http_type = MCPServerConfigHTTPType(obj.get("McpServerConfigHttpType"))
         mcp_server_config_local = MCPServerConfigLocal.from_dict(obj.get("McpServerConfigLocal"))
         mcp_server_config_local_type = MCPServerConfigLocalType(obj.get("McpServerConfigLocalType"))
@@ -5984,7 +5998,7 @@ class RPC:
         workspaces_list_files_result = WorkspacesListFilesResult.from_dict(obj.get("WorkspacesListFilesResult"))
         workspaces_read_file_request = WorkspacesReadFileRequest.from_dict(obj.get("WorkspacesReadFileRequest"))
         workspaces_read_file_result = WorkspacesReadFileResult.from_dict(obj.get("WorkspacesReadFileResult"))
-        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, commands_handle_pending_command_request, commands_handle_pending_command_result, current_model, discovered_mcp_server, discovered_mcp_server_source, discovered_mcp_server_type, embedded_blob_resource_contents, embedded_text_resource_contents, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, filter_mapping, filter_mapping_string, filter_mapping_value, fleet_start_request, fleet_start_result, handle_pending_tool_call_request, handle_pending_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_type, mcp_server_config_local, mcp_server_config_local_type, mcp_server_list, mcp_server_source, mcp_server_status, model, model_billing, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_policy, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, task_agent_info, task_agent_info_execution_mode, task_agent_info_status, task_info, task_list, tasks_cancel_request, tasks_cancel_result, task_shell_info, task_shell_info_attachment_mode, task_shell_info_execution_mode, task_shell_info_status, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_remove_request, tasks_remove_result, tasks_start_agent_request, tasks_start_agent_result, tool, tool_list, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
+        return RPC(account_get_quota_request, account_get_quota_result, account_quota_snapshot, agent_get_current_result, agent_info, agent_list, agent_reload_result, agent_select_request, agent_select_result, auth_info_type, commands_handle_pending_command_request, commands_handle_pending_command_result, current_model, discovered_mcp_server, discovered_mcp_server_source, discovered_mcp_server_type, embedded_blob_resource_contents, embedded_text_resource_contents, extension, extension_list, extensions_disable_request, extensions_enable_request, extension_source, extension_status, external_tool_result, external_tool_text_result_for_llm, external_tool_text_result_for_llm_content, external_tool_text_result_for_llm_content_audio, external_tool_text_result_for_llm_content_image, external_tool_text_result_for_llm_content_resource, external_tool_text_result_for_llm_content_resource_details, external_tool_text_result_for_llm_content_resource_link, external_tool_text_result_for_llm_content_resource_link_icon, external_tool_text_result_for_llm_content_resource_link_icon_theme, external_tool_text_result_for_llm_content_terminal, external_tool_text_result_for_llm_content_text, filter_mapping, filter_mapping_string, filter_mapping_value, fleet_start_request, fleet_start_result, handle_pending_tool_call_request, handle_pending_tool_call_result, history_compact_context_window, history_compact_result, history_truncate_request, history_truncate_result, instructions_get_sources_result, instructions_sources, instructions_sources_location, instructions_sources_type, log_request, log_result, mcp_config_add_request, mcp_config_disable_request, mcp_config_enable_request, mcp_config_list, mcp_config_remove_request, mcp_config_update_request, mcp_disable_request, mcp_discover_request, mcp_discover_result, mcp_enable_request, mcp_oauth_login_request, mcp_oauth_login_result, mcp_server, mcp_server_config, mcp_server_config_http, mcp_server_config_http_oauth_grant_type, mcp_server_config_http_type, mcp_server_config_local, mcp_server_config_local_type, mcp_server_list, mcp_server_source, mcp_server_status, model, model_billing, model_capabilities, model_capabilities_limits, model_capabilities_limits_vision, model_capabilities_override, model_capabilities_override_limits, model_capabilities_override_limits_vision, model_capabilities_override_supports, model_capabilities_supports, model_list, model_policy, models_list_request, model_switch_to_request, model_switch_to_result, mode_set_request, name_get_result, name_set_request, permission_decision, permission_decision_approve_for_location, permission_decision_approve_for_location_approval, permission_decision_approve_for_location_approval_commands, permission_decision_approve_for_location_approval_custom_tool, permission_decision_approve_for_location_approval_mcp, permission_decision_approve_for_location_approval_mcp_sampling, permission_decision_approve_for_location_approval_memory, permission_decision_approve_for_location_approval_read, permission_decision_approve_for_location_approval_write, permission_decision_approve_for_session, permission_decision_approve_for_session_approval, permission_decision_approve_for_session_approval_commands, permission_decision_approve_for_session_approval_custom_tool, permission_decision_approve_for_session_approval_mcp, permission_decision_approve_for_session_approval_mcp_sampling, permission_decision_approve_for_session_approval_memory, permission_decision_approve_for_session_approval_read, permission_decision_approve_for_session_approval_write, permission_decision_approve_once, permission_decision_approve_permanently, permission_decision_reject, permission_decision_request, permission_decision_user_not_available, permission_request_result, permissions_reset_session_approvals_request, permissions_reset_session_approvals_result, permissions_set_approve_all_request, permissions_set_approve_all_result, ping_request, ping_result, plan_read_result, plan_update_request, plugin, plugin_list, server_skill, server_skill_list, session_auth_status, session_fs_append_file_request, session_fs_error, session_fs_error_code, session_fs_exists_request, session_fs_exists_result, session_fs_mkdir_request, session_fs_readdir_request, session_fs_readdir_result, session_fs_readdir_with_types_entry, session_fs_readdir_with_types_entry_type, session_fs_readdir_with_types_request, session_fs_readdir_with_types_result, session_fs_read_file_request, session_fs_read_file_result, session_fs_rename_request, session_fs_rm_request, session_fs_set_provider_conventions, session_fs_set_provider_request, session_fs_set_provider_result, session_fs_stat_request, session_fs_stat_result, session_fs_write_file_request, session_log_level, session_mode, sessions_fork_request, sessions_fork_result, shell_exec_request, shell_exec_result, shell_kill_request, shell_kill_result, shell_kill_signal, skill, skill_list, skills_config_set_disabled_skills_request, skills_disable_request, skills_discover_request, skills_enable_request, task_agent_info, task_agent_info_execution_mode, task_agent_info_status, task_info, task_list, tasks_cancel_request, tasks_cancel_result, task_shell_info, task_shell_info_attachment_mode, task_shell_info_execution_mode, task_shell_info_status, tasks_promote_to_background_request, tasks_promote_to_background_result, tasks_remove_request, tasks_remove_result, tasks_start_agent_request, tasks_start_agent_result, tool, tool_list, tools_list_request, ui_elicitation_array_any_of_field, ui_elicitation_array_any_of_field_items, ui_elicitation_array_any_of_field_items_any_of, ui_elicitation_array_enum_field, ui_elicitation_array_enum_field_items, ui_elicitation_field_value, ui_elicitation_request, ui_elicitation_response, ui_elicitation_response_action, ui_elicitation_response_content, ui_elicitation_result, ui_elicitation_schema, ui_elicitation_schema_property, ui_elicitation_schema_property_boolean, ui_elicitation_schema_property_number, ui_elicitation_schema_property_number_type, ui_elicitation_schema_property_string, ui_elicitation_schema_property_string_format, ui_elicitation_string_enum_field, ui_elicitation_string_one_of_field, ui_elicitation_string_one_of_field_one_of, ui_handle_pending_elicitation_request, usage_get_metrics_result, usage_metrics_code_changes, usage_metrics_model_metric, usage_metrics_model_metric_requests, usage_metrics_model_metric_token_detail, usage_metrics_model_metric_usage, usage_metrics_token_detail, workspaces_create_file_request, workspaces_get_workspace_result, workspaces_list_files_result, workspaces_read_file_request, workspaces_read_file_result)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -6056,6 +6070,7 @@ class RPC:
         result["McpServer"] = to_class(MCPServer, self.mcp_server)
         result["McpServerConfig"] = to_class(MCPServerConfig, self.mcp_server_config)
         result["McpServerConfigHttp"] = to_class(MCPServerConfigHTTP, self.mcp_server_config_http)
+        result["McpServerConfigHttpOauthGrantType"] = to_enum(MCPServerConfigHTTPOauthGrantType, self.mcp_server_config_http_oauth_grant_type)
         result["McpServerConfigHttpType"] = to_enum(MCPServerConfigHTTPType, self.mcp_server_config_http_type)
         result["McpServerConfigLocal"] = to_class(MCPServerConfigLocal, self.mcp_server_config_local)
         result["McpServerConfigLocalType"] = to_enum(MCPServerConfigLocalType, self.mcp_server_config_local_type)

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -1556,21 +1556,26 @@ class McpOauthRequiredData:
 class McpOauthRequiredStaticClientConfig:
     "Static OAuth client configuration, if the server specifies one"
     client_id: str
+    grant_type: str | None = None
     public_client: bool | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "McpOauthRequiredStaticClientConfig":
         assert isinstance(obj, dict)
         client_id = from_str(obj.get("clientId"))
+        grant_type = from_union([from_none, from_str], obj.get("grantType"))
         public_client = from_union([from_none, from_bool], obj.get("publicClient"))
         return McpOauthRequiredStaticClientConfig(
             client_id=client_id,
+            grant_type=grant_type,
             public_client=public_client,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["clientId"] = from_str(self.client_id)
+        if self.grant_type is not None:
+            result["grantType"] = from_union([from_none, from_str], self.grant_type)
         if self.public_client is not None:
             result["publicClient"] = from_union([from_none, from_bool], self.public_client)
         return result

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -307,6 +307,7 @@ class AssistantMessageData:
     reasoning_text: str | None = None
     request_id: str | None = None
     tool_requests: list[AssistantMessageToolRequest] | None = None
+    turn_id: str | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "AssistantMessageData":
@@ -322,6 +323,7 @@ class AssistantMessageData:
         reasoning_text = from_union([from_none, from_str], obj.get("reasoningText"))
         request_id = from_union([from_none, from_str], obj.get("requestId"))
         tool_requests = from_union([from_none, lambda x: from_list(AssistantMessageToolRequest.from_dict, x)], obj.get("toolRequests"))
+        turn_id = from_union([from_none, from_str], obj.get("turnId"))
         return AssistantMessageData(
             content=content,
             message_id=message_id,
@@ -334,6 +336,7 @@ class AssistantMessageData:
             reasoning_text=reasoning_text,
             request_id=request_id,
             tool_requests=tool_requests,
+            turn_id=turn_id,
         )
 
     def to_dict(self) -> dict:
@@ -358,6 +361,8 @@ class AssistantMessageData:
             result["requestId"] = from_union([from_none, from_str], self.request_id)
         if self.tool_requests is not None:
             result["toolRequests"] = from_union([from_none, lambda x: from_list(lambda x: to_class(AssistantMessageToolRequest, x), x)], self.tool_requests)
+        if self.turn_id is not None:
+            result["turnId"] = from_union([from_none, from_str], self.turn_id)
         return result
 
 
@@ -1673,14 +1678,14 @@ class PendingMessagesModifiedData:
 class PermissionCompletedData:
     "Permission request completion notification signaling UI dismissal"
     request_id: str
-    result: PermissionCompletedResult
+    result: PermissionResult
     tool_call_id: str | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "PermissionCompletedData":
         assert isinstance(obj, dict)
         request_id = from_str(obj.get("requestId"))
-        result = PermissionCompletedResult.from_dict(obj.get("result"))
+        result = PermissionResult.from_dict(obj.get("result"))
         tool_call_id = from_union([from_none, from_str], obj.get("toolCallId"))
         return PermissionCompletedData(
             request_id=request_id,
@@ -1691,28 +1696,9 @@ class PermissionCompletedData:
     def to_dict(self) -> dict:
         result: dict = {}
         result["requestId"] = from_str(self.request_id)
-        result["result"] = to_class(PermissionCompletedResult, self.result)
+        result["result"] = to_class(PermissionResult, self.result)
         if self.tool_call_id is not None:
             result["toolCallId"] = from_union([from_none, from_str], self.tool_call_id)
-        return result
-
-
-@dataclass
-class PermissionCompletedResult:
-    "The result of the permission request"
-    kind: PermissionCompletedKind
-
-    @staticmethod
-    def from_dict(obj: Any) -> "PermissionCompletedResult":
-        assert isinstance(obj, dict)
-        kind = parse_enum(PermissionCompletedKind, obj.get("kind"))
-        return PermissionCompletedResult(
-            kind=kind,
-        )
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["kind"] = to_enum(PermissionCompletedKind, self.kind)
         return result
 
 
@@ -2094,6 +2080,92 @@ class PermissionRequestedData:
             result["promptRequest"] = from_union([from_none, lambda x: to_class(PermissionPromptRequest, x)], self.prompt_request)
         if self.resolved_by_hook is not None:
             result["resolvedByHook"] = from_union([from_none, from_bool], self.resolved_by_hook)
+        return result
+
+
+@dataclass
+class PermissionResult:
+    "The result of the permission request"
+    kind: PermissionResultKind
+    approval: UserToolSessionApproval | None = None
+    feedback: str | None = None
+    force_reject: bool | None = None
+    interrupt: bool | None = None
+    location_key: str | None = None
+    message: str | None = None
+    path: str | None = None
+    reason: str | None = None
+    rules: list[PermissionRule] | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> "PermissionResult":
+        assert isinstance(obj, dict)
+        kind = parse_enum(PermissionResultKind, obj.get("kind"))
+        approval = from_union([from_none, UserToolSessionApproval.from_dict], obj.get("approval"))
+        feedback = from_union([from_none, from_str], obj.get("feedback"))
+        force_reject = from_union([from_none, from_bool], obj.get("forceReject"))
+        interrupt = from_union([from_none, from_bool], obj.get("interrupt"))
+        location_key = from_union([from_none, from_str], obj.get("locationKey"))
+        message = from_union([from_none, from_str], obj.get("message"))
+        path = from_union([from_none, from_str], obj.get("path"))
+        reason = from_union([from_none, from_str], obj.get("reason"))
+        rules = from_union([from_none, lambda x: from_list(PermissionRule.from_dict, x)], obj.get("rules"))
+        return PermissionResult(
+            kind=kind,
+            approval=approval,
+            feedback=feedback,
+            force_reject=force_reject,
+            interrupt=interrupt,
+            location_key=location_key,
+            message=message,
+            path=path,
+            reason=reason,
+            rules=rules,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(PermissionResultKind, self.kind)
+        if self.approval is not None:
+            result["approval"] = from_union([from_none, lambda x: to_class(UserToolSessionApproval, x)], self.approval)
+        if self.feedback is not None:
+            result["feedback"] = from_union([from_none, from_str], self.feedback)
+        if self.force_reject is not None:
+            result["forceReject"] = from_union([from_none, from_bool], self.force_reject)
+        if self.interrupt is not None:
+            result["interrupt"] = from_union([from_none, from_bool], self.interrupt)
+        if self.location_key is not None:
+            result["locationKey"] = from_union([from_none, from_str], self.location_key)
+        if self.message is not None:
+            result["message"] = from_union([from_none, from_str], self.message)
+        if self.path is not None:
+            result["path"] = from_union([from_none, from_str], self.path)
+        if self.reason is not None:
+            result["reason"] = from_union([from_none, from_str], self.reason)
+        if self.rules is not None:
+            result["rules"] = from_union([from_none, lambda x: from_list(lambda x: to_class(PermissionRule, x), x)], self.rules)
+        return result
+
+
+@dataclass
+class PermissionRule:
+    argument: str | None
+    kind: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> "PermissionRule":
+        assert isinstance(obj, dict)
+        argument = from_union([from_none, from_str], obj.get("argument"))
+        kind = from_str(obj.get("kind"))
+        return PermissionRule(
+            argument=argument,
+            kind=kind,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["argument"] = from_union([from_none, from_str], self.argument)
+        result["kind"] = from_str(self.kind)
         return result
 
 
@@ -2672,9 +2744,11 @@ class SessionResumeData:
     resume_time: datetime
     already_in_use: bool | None = None
     context: WorkingDirectoryContext | None = None
+    continue_pending_work: bool | None = None
     reasoning_effort: str | None = None
     remote_steerable: bool | None = None
     selected_model: str | None = None
+    session_was_active: bool | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionResumeData":
@@ -2683,17 +2757,21 @@ class SessionResumeData:
         resume_time = from_datetime(obj.get("resumeTime"))
         already_in_use = from_union([from_none, from_bool], obj.get("alreadyInUse"))
         context = from_union([from_none, WorkingDirectoryContext.from_dict], obj.get("context"))
+        continue_pending_work = from_union([from_none, from_bool], obj.get("continuePendingWork"))
         reasoning_effort = from_union([from_none, from_str], obj.get("reasoningEffort"))
         remote_steerable = from_union([from_none, from_bool], obj.get("remoteSteerable"))
         selected_model = from_union([from_none, from_str], obj.get("selectedModel"))
+        session_was_active = from_union([from_none, from_bool], obj.get("sessionWasActive"))
         return SessionResumeData(
             event_count=event_count,
             resume_time=resume_time,
             already_in_use=already_in_use,
             context=context,
+            continue_pending_work=continue_pending_work,
             reasoning_effort=reasoning_effort,
             remote_steerable=remote_steerable,
             selected_model=selected_model,
+            session_was_active=session_was_active,
         )
 
     def to_dict(self) -> dict:
@@ -2704,12 +2782,16 @@ class SessionResumeData:
             result["alreadyInUse"] = from_union([from_none, from_bool], self.already_in_use)
         if self.context is not None:
             result["context"] = from_union([from_none, lambda x: to_class(WorkingDirectoryContext, x)], self.context)
+        if self.continue_pending_work is not None:
+            result["continuePendingWork"] = from_union([from_none, from_bool], self.continue_pending_work)
         if self.reasoning_effort is not None:
             result["reasoningEffort"] = from_union([from_none, from_str], self.reasoning_effort)
         if self.remote_steerable is not None:
             result["remoteSteerable"] = from_union([from_none, from_bool], self.remote_steerable)
         if self.selected_model is not None:
             result["selectedModel"] = from_union([from_none, from_str], self.selected_model)
+        if self.session_was_active is not None:
+            result["sessionWasActive"] = from_union([from_none, from_bool], self.session_was_active)
         return result
 
 
@@ -2727,7 +2809,9 @@ class SessionShutdownData:
     current_tokens: float | None = None
     error_reason: str | None = None
     system_tokens: float | None = None
+    token_details: dict[str, ShutdownTokenDetail] | None = None
     tool_definitions_tokens: float | None = None
+    total_nano_aiu: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SessionShutdownData":
@@ -2743,7 +2827,9 @@ class SessionShutdownData:
         current_tokens = from_union([from_none, from_float], obj.get("currentTokens"))
         error_reason = from_union([from_none, from_str], obj.get("errorReason"))
         system_tokens = from_union([from_none, from_float], obj.get("systemTokens"))
+        token_details = from_union([from_none, lambda x: from_dict(ShutdownTokenDetail.from_dict, x)], obj.get("tokenDetails"))
         tool_definitions_tokens = from_union([from_none, from_float], obj.get("toolDefinitionsTokens"))
+        total_nano_aiu = from_union([from_none, from_float], obj.get("totalNanoAiu"))
         return SessionShutdownData(
             code_changes=code_changes,
             model_metrics=model_metrics,
@@ -2756,7 +2842,9 @@ class SessionShutdownData:
             current_tokens=current_tokens,
             error_reason=error_reason,
             system_tokens=system_tokens,
+            token_details=token_details,
             tool_definitions_tokens=tool_definitions_tokens,
+            total_nano_aiu=total_nano_aiu,
         )
 
     def to_dict(self) -> dict:
@@ -2777,8 +2865,12 @@ class SessionShutdownData:
             result["errorReason"] = from_union([from_none, from_str], self.error_reason)
         if self.system_tokens is not None:
             result["systemTokens"] = from_union([from_none, to_float], self.system_tokens)
+        if self.token_details is not None:
+            result["tokenDetails"] = from_union([from_none, lambda x: from_dict(lambda x: to_class(ShutdownTokenDetail, x), x)], self.token_details)
         if self.tool_definitions_tokens is not None:
             result["toolDefinitionsTokens"] = from_union([from_none, to_float], self.tool_definitions_tokens)
+        if self.total_nano_aiu is not None:
+            result["totalNanoAiu"] = from_union([from_none, to_float], self.total_nano_aiu)
         return result
 
 
@@ -3121,21 +3213,31 @@ class ShutdownCodeChanges:
 class ShutdownModelMetric:
     requests: ShutdownModelMetricRequests
     usage: ShutdownModelMetricUsage
+    token_details: dict[str, ShutdownModelMetricTokenDetail] | None = None
+    total_nano_aiu: float | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "ShutdownModelMetric":
         assert isinstance(obj, dict)
         requests = ShutdownModelMetricRequests.from_dict(obj.get("requests"))
         usage = ShutdownModelMetricUsage.from_dict(obj.get("usage"))
+        token_details = from_union([from_none, lambda x: from_dict(ShutdownModelMetricTokenDetail.from_dict, x)], obj.get("tokenDetails"))
+        total_nano_aiu = from_union([from_none, from_float], obj.get("totalNanoAiu"))
         return ShutdownModelMetric(
             requests=requests,
             usage=usage,
+            token_details=token_details,
+            total_nano_aiu=total_nano_aiu,
         )
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["requests"] = to_class(ShutdownModelMetricRequests, self.requests)
         result["usage"] = to_class(ShutdownModelMetricUsage, self.usage)
+        if self.token_details is not None:
+            result["tokenDetails"] = from_union([from_none, lambda x: from_dict(lambda x: to_class(ShutdownModelMetricTokenDetail, x), x)], self.token_details)
+        if self.total_nano_aiu is not None:
+            result["totalNanoAiu"] = from_union([from_none, to_float], self.total_nano_aiu)
         return result
 
 
@@ -3159,6 +3261,24 @@ class ShutdownModelMetricRequests:
         result: dict = {}
         result["cost"] = to_float(self.cost)
         result["count"] = to_float(self.count)
+        return result
+
+
+@dataclass
+class ShutdownModelMetricTokenDetail:
+    token_count: float
+
+    @staticmethod
+    def from_dict(obj: Any) -> "ShutdownModelMetricTokenDetail":
+        assert isinstance(obj, dict)
+        token_count = from_float(obj.get("tokenCount"))
+        return ShutdownModelMetricTokenDetail(
+            token_count=token_count,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["tokenCount"] = to_float(self.token_count)
         return result
 
 
@@ -3195,6 +3315,24 @@ class ShutdownModelMetricUsage:
         result["outputTokens"] = to_float(self.output_tokens)
         if self.reasoning_tokens is not None:
             result["reasoningTokens"] = from_union([from_none, to_float], self.reasoning_tokens)
+        return result
+
+
+@dataclass
+class ShutdownTokenDetail:
+    token_count: float
+
+    @staticmethod
+    def from_dict(obj: Any) -> "ShutdownTokenDetail":
+        assert isinstance(obj, dict)
+        token_count = from_float(obj.get("tokenCount"))
+        return ShutdownTokenDetail(
+            token_count=token_count,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["tokenCount"] = to_float(self.token_count)
         return result
 
 
@@ -3748,6 +3886,7 @@ class ToolExecutionCompleteData:
     parent_tool_call_id: str | None = None
     result: ToolExecutionCompleteResult | None = None
     tool_telemetry: dict[str, Any] | None = None
+    turn_id: str | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "ToolExecutionCompleteData":
@@ -3761,6 +3900,7 @@ class ToolExecutionCompleteData:
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
         result = from_union([from_none, ToolExecutionCompleteResult.from_dict], obj.get("result"))
         tool_telemetry = from_union([from_none, lambda x: from_dict(lambda x: x, x)], obj.get("toolTelemetry"))
+        turn_id = from_union([from_none, from_str], obj.get("turnId"))
         return ToolExecutionCompleteData(
             success=success,
             tool_call_id=tool_call_id,
@@ -3771,6 +3911,7 @@ class ToolExecutionCompleteData:
             parent_tool_call_id=parent_tool_call_id,
             result=result,
             tool_telemetry=tool_telemetry,
+            turn_id=turn_id,
         )
 
     def to_dict(self) -> dict:
@@ -3791,6 +3932,8 @@ class ToolExecutionCompleteData:
             result["result"] = from_union([from_none, lambda x: to_class(ToolExecutionCompleteResult, x)], self.result)
         if self.tool_telemetry is not None:
             result["toolTelemetry"] = from_union([from_none, lambda x: from_dict(lambda x: x, x)], self.tool_telemetry)
+        if self.turn_id is not None:
+            result["turnId"] = from_union([from_none, from_str], self.turn_id)
         return result
 
 
@@ -3903,6 +4046,7 @@ class ToolExecutionStartData:
     mcp_tool_name: str | None = None
     # Deprecated: this field is deprecated.
     parent_tool_call_id: str | None = None
+    turn_id: str | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "ToolExecutionStartData":
@@ -3913,6 +4057,7 @@ class ToolExecutionStartData:
         mcp_server_name = from_union([from_none, from_str], obj.get("mcpServerName"))
         mcp_tool_name = from_union([from_none, from_str], obj.get("mcpToolName"))
         parent_tool_call_id = from_union([from_none, from_str], obj.get("parentToolCallId"))
+        turn_id = from_union([from_none, from_str], obj.get("turnId"))
         return ToolExecutionStartData(
             tool_call_id=tool_call_id,
             tool_name=tool_name,
@@ -3920,6 +4065,7 @@ class ToolExecutionStartData:
             mcp_server_name=mcp_server_name,
             mcp_tool_name=mcp_tool_name,
             parent_tool_call_id=parent_tool_call_id,
+            turn_id=turn_id,
         )
 
     def to_dict(self) -> dict:
@@ -3934,6 +4080,8 @@ class ToolExecutionStartData:
             result["mcpToolName"] = from_union([from_none, from_str], self.mcp_tool_name)
         if self.parent_tool_call_id is not None:
             result["parentToolCallId"] = from_union([from_none, from_str], self.parent_tool_call_id)
+        if self.turn_id is not None:
+            result["turnId"] = from_union([from_none, from_str], self.turn_id)
         return result
 
 
@@ -4215,6 +4363,7 @@ class UserMessageData:
     attachments: list[UserMessageAttachment] | None = None
     interaction_id: str | None = None
     native_document_path_fallback_paths: list[str] | None = None
+    parent_agent_task_id: str | None = None
     source: str | None = None
     supported_native_document_mime_types: list[str] | None = None
     transformed_content: str | None = None
@@ -4227,6 +4376,7 @@ class UserMessageData:
         attachments = from_union([from_none, lambda x: from_list(UserMessageAttachment.from_dict, x)], obj.get("attachments"))
         interaction_id = from_union([from_none, from_str], obj.get("interactionId"))
         native_document_path_fallback_paths = from_union([from_none, lambda x: from_list(from_str, x)], obj.get("nativeDocumentPathFallbackPaths"))
+        parent_agent_task_id = from_union([from_none, from_str], obj.get("parentAgentTaskId"))
         source = from_union([from_none, from_str], obj.get("source"))
         supported_native_document_mime_types = from_union([from_none, lambda x: from_list(from_str, x)], obj.get("supportedNativeDocumentMimeTypes"))
         transformed_content = from_union([from_none, from_str], obj.get("transformedContent"))
@@ -4236,6 +4386,7 @@ class UserMessageData:
             attachments=attachments,
             interaction_id=interaction_id,
             native_document_path_fallback_paths=native_document_path_fallback_paths,
+            parent_agent_task_id=parent_agent_task_id,
             source=source,
             supported_native_document_mime_types=supported_native_document_mime_types,
             transformed_content=transformed_content,
@@ -4252,12 +4403,48 @@ class UserMessageData:
             result["interactionId"] = from_union([from_none, from_str], self.interaction_id)
         if self.native_document_path_fallback_paths is not None:
             result["nativeDocumentPathFallbackPaths"] = from_union([from_none, lambda x: from_list(from_str, x)], self.native_document_path_fallback_paths)
+        if self.parent_agent_task_id is not None:
+            result["parentAgentTaskId"] = from_union([from_none, from_str], self.parent_agent_task_id)
         if self.source is not None:
             result["source"] = from_union([from_none, from_str], self.source)
         if self.supported_native_document_mime_types is not None:
             result["supportedNativeDocumentMimeTypes"] = from_union([from_none, lambda x: from_list(from_str, x)], self.supported_native_document_mime_types)
         if self.transformed_content is not None:
             result["transformedContent"] = from_union([from_none, from_str], self.transformed_content)
+        return result
+
+
+@dataclass
+class UserToolSessionApproval:
+    "The approval to add as a session-scoped rule"
+    kind: UserToolSessionApprovalKind
+    command_identifiers: list[str] | None = None
+    server_name: str | None = None
+    tool_name: str | None = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> "UserToolSessionApproval":
+        assert isinstance(obj, dict)
+        kind = parse_enum(UserToolSessionApprovalKind, obj.get("kind"))
+        command_identifiers = from_union([from_none, lambda x: from_list(from_str, x)], obj.get("commandIdentifiers"))
+        server_name = from_union([from_none, from_str], obj.get("serverName"))
+        tool_name = from_union([from_none, from_str], obj.get("toolName"))
+        return UserToolSessionApproval(
+            kind=kind,
+            command_identifiers=command_identifiers,
+            server_name=server_name,
+            tool_name=tool_name,
+        )
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["kind"] = to_enum(UserToolSessionApprovalKind, self.kind)
+        if self.command_identifiers is not None:
+            result["commandIdentifiers"] = from_union([from_none, lambda x: from_list(from_str, x)], self.command_identifiers)
+        if self.server_name is not None:
+            result["serverName"] = from_union([from_none, from_str], self.server_name)
+        if self.tool_name is not None:
+            result["toolName"] = from_union([from_none, from_str], self.tool_name)
         return result
 
 
@@ -4381,18 +4568,6 @@ class ModelCallFailureSource(Enum):
     MCP_SAMPLING = "mcp_sampling"
 
 
-class PermissionCompletedKind(Enum):
-    "The outcome of the permission request"
-    APPROVED = "approved"
-    APPROVED_FOR_SESSION = "approved-for-session"
-    APPROVED_FOR_LOCATION = "approved-for-location"
-    DENIED_BY_RULES = "denied-by-rules"
-    DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
-    DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
-    DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
-    DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
-
-
 class PermissionPromptRequestKind(Enum):
     "Derived user-facing permission prompt details for UI consumers discriminator"
     COMMANDS = "commands"
@@ -4447,6 +4622,19 @@ class PermissionRequestMemoryDirection(Enum):
     "Vote direction (vote only)"
     UPVOTE = "upvote"
     DOWNVOTE = "downvote"
+
+
+class PermissionResultKind(Enum):
+    "The result of the permission request discriminator"
+    APPROVED = "approved"
+    APPROVED_FOR_SESSION = "approved-for-session"
+    APPROVED_FOR_LOCATION = "approved-for-location"
+    CANCELLED = "cancelled"
+    DENIED_BY_RULES = "denied-by-rules"
+    DENIED_NO_APPROVAL_RULE_AND_COULD_NOT_REQUEST_FROM_USER = "denied-no-approval-rule-and-could-not-request-from-user"
+    DENIED_INTERACTIVELY_BY_USER = "denied-interactively-by-user"
+    DENIED_BY_CONTENT_EXCLUSION_POLICY = "denied-by-content-exclusion-policy"
+    DENIED_BY_PERMISSION_REQUEST_HOOK = "denied-by-permission-request-hook"
 
 
 class PlanChangedOperation(Enum):
@@ -4522,6 +4710,16 @@ class UserMessageAttachmentType(Enum):
     SELECTION = "selection"
     GITHUB_REFERENCE = "github_reference"
     BLOB = "blob"
+
+
+class UserToolSessionApprovalKind(Enum):
+    "The approval to add as a session-scoped rule discriminator"
+    COMMANDS = "commands"
+    READ = "read"
+    WRITE = "write"
+    MCP = "mcp"
+    MEMORY = "memory"
+    CUSTOM_TOOL = "custom-tool"
 
 
 class WorkingDirectoryContextHostType(Enum):

--- a/python/copilot/generated/session_events.py
+++ b/python/copilot/generated/session_events.py
@@ -3523,8 +3523,11 @@ class SystemNotification:
     sender_name: str | None = None
     sender_type: str | None = None
     shell_id: str | None = None
+    source_path: str | None = None
     status: SystemNotificationAgentCompletedStatus | None = None
     summary: str | None = None
+    trigger_file: str | None = None
+    trigger_tool: str | None = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SystemNotification":
@@ -3539,8 +3542,11 @@ class SystemNotification:
         sender_name = from_union([from_none, from_str], obj.get("senderName"))
         sender_type = from_union([from_none, from_str], obj.get("senderType"))
         shell_id = from_union([from_none, from_str], obj.get("shellId"))
+        source_path = from_union([from_none, from_str], obj.get("sourcePath"))
         status = from_union([from_none, lambda x: parse_enum(SystemNotificationAgentCompletedStatus, x)], obj.get("status"))
         summary = from_union([from_none, from_str], obj.get("summary"))
+        trigger_file = from_union([from_none, from_str], obj.get("triggerFile"))
+        trigger_tool = from_union([from_none, from_str], obj.get("triggerTool"))
         return SystemNotification(
             type=type,
             agent_id=agent_id,
@@ -3552,8 +3558,11 @@ class SystemNotification:
             sender_name=sender_name,
             sender_type=sender_type,
             shell_id=shell_id,
+            source_path=source_path,
             status=status,
             summary=summary,
+            trigger_file=trigger_file,
+            trigger_tool=trigger_tool,
         )
 
     def to_dict(self) -> dict:
@@ -3577,10 +3586,16 @@ class SystemNotification:
             result["senderType"] = from_union([from_none, from_str], self.sender_type)
         if self.shell_id is not None:
             result["shellId"] = from_union([from_none, from_str], self.shell_id)
+        if self.source_path is not None:
+            result["sourcePath"] = from_union([from_none, from_str], self.source_path)
         if self.status is not None:
             result["status"] = from_union([from_none, lambda x: to_enum(SystemNotificationAgentCompletedStatus, x)], self.status)
         if self.summary is not None:
             result["summary"] = from_union([from_none, from_str], self.summary)
+        if self.trigger_file is not None:
+            result["triggerFile"] = from_union([from_none, from_str], self.trigger_file)
+        if self.trigger_tool is not None:
+            result["triggerTool"] = from_union([from_none, from_str], self.trigger_tool)
         return result
 
 
@@ -4466,6 +4481,7 @@ class SystemNotificationType(Enum):
     NEW_INBOX_MESSAGE = "new_inbox_message"
     SHELL_COMPLETED = "shell_completed"
     SHELL_DETACHED_COMPLETED = "shell_detached_completed"
+    INSTRUCTION_DISCOVERED = "instruction_discovered"
 
 
 class ToolExecutionCompleteContentResourceLinkIconTheme(Enum):

--- a/python/copilot/session.py
+++ b/python/copilot/session.py
@@ -24,6 +24,8 @@ from ._telemetry import get_trace_context, trace_context
 from .generated.rpc import (
     ClientSessionApiHandlers,
     CommandsHandlePendingCommandRequest,
+    ExternalToolTextResultForLlm,
+    HandlePendingToolCallRequest,
     LogRequest,
     ModelSwitchToRequest,
     PermissionDecision,
@@ -31,8 +33,6 @@ from .generated.rpc import (
     PermissionDecisionRequest,
     SessionLogLevel,
     SessionRpc,
-    ToolCallResult,
-    ToolsHandlePendingToolCallRequest,
     UIElicitationRequest,
     UIElicitationResponse,
     UIElicitationResponseAction,
@@ -962,6 +962,15 @@ class ResumeSessionConfig(TypedDict, total=False):
     # When True, skips emitting the session.resume event.
     # Useful for reconnecting to a session without triggering resume-related side effects.
     disable_resume: bool
+    # When True, instructs the runtime to continue any tool calls or permission prompts
+    # that were still pending when the session was last suspended. When False (the
+    # default), the runtime treats pending work as interrupted on resume.
+    #
+    # For permission requests, the runtime re-emits ``permission.requested`` so the
+    # registered ``on_permission_request`` handler can re-prompt; for external tool
+    # calls, the consumer is expected to supply the result via the corresponding
+    # low-level RPC method.
+    continue_pending_work: bool
     # Optional event handler registered before the session.resume RPC is issued,
     # ensuring early events are delivered. See SessionConfig.on_event.
     on_event: Callable[[SessionEvent], None]
@@ -1403,16 +1412,16 @@ class CopilotSession:
             # failures send the full structured result to preserve metadata.
             if tool_result._from_exception:
                 await self.rpc.tools.handle_pending_tool_call(
-                    ToolsHandlePendingToolCallRequest(
+                    HandlePendingToolCallRequest(
                         request_id=request_id,
                         error=tool_result.error,
                     )
                 )
             else:
                 await self.rpc.tools.handle_pending_tool_call(
-                    ToolsHandlePendingToolCallRequest(
+                    HandlePendingToolCallRequest(
                         request_id=request_id,
-                        result=ToolCallResult(
+                        result=ExternalToolTextResultForLlm(
                             text_result_for_llm=tool_result.text_result_for_llm,
                             error=tool_result.error,
                             result_type=tool_result.result_type,
@@ -1423,7 +1432,7 @@ class CopilotSession:
         except Exception as exc:
             try:
                 await self.rpc.tools.handle_pending_tool_call(
-                    ToolsHandlePendingToolCallRequest(
+                    HandlePendingToolCallRequest(
                         request_id=request_id,
                         error=str(exc),
                     )

--- a/python/e2e/test_commands.py
+++ b/python/e2e/test_commands.py
@@ -7,6 +7,7 @@ trigger a ``commands.changed`` broadcast event visible to the first client.
 """
 
 import asyncio
+import contextlib
 import os
 import shutil
 import tempfile
@@ -106,7 +107,8 @@ class CommandsMultiClientContext:
                 if item.is_dir():
                     shutil.rmtree(item, ignore_errors=True)
                 else:
-                    item.unlink(missing_ok=True)
+                    with contextlib.suppress(OSError):
+                        item.unlink(missing_ok=True)
 
     def _get_env(self) -> dict:
         env = os.environ.copy()

--- a/python/e2e/test_multi_client.py
+++ b/python/e2e/test_multi_client.py
@@ -5,6 +5,7 @@ multiple clients are connected to the same CLI server session.
 """
 
 import asyncio
+import contextlib
 import os
 import shutil
 import tempfile
@@ -110,19 +111,17 @@ class MultiClientContext:
         if self._proxy:
             await self._proxy.configure(abs_snapshot_path, self.work_dir)
 
-        # Clear temp directories between tests
+        # Clear temp directories between tests; tolerate Windows holding the
+        # SQLite session-store.db open briefly after the CLI subprocess exits.
         from pathlib import Path
 
-        for item in Path(self.home_dir).iterdir():
-            if item.is_dir():
-                shutil.rmtree(item, ignore_errors=True)
-            else:
-                item.unlink(missing_ok=True)
-        for item in Path(self.work_dir).iterdir():
-            if item.is_dir():
-                shutil.rmtree(item, ignore_errors=True)
-            else:
-                item.unlink(missing_ok=True)
+        for base_dir in (self.home_dir, self.work_dir):
+            for item in Path(base_dir).iterdir():
+                if item.is_dir():
+                    shutil.rmtree(item, ignore_errors=True)
+                else:
+                    with contextlib.suppress(OSError):
+                        item.unlink(missing_ok=True)
 
     def get_env(self) -> dict:
         env = os.environ.copy()

--- a/python/e2e/test_ui_elicitation_multi_client.py
+++ b/python/e2e/test_ui_elicitation_multi_client.py
@@ -8,6 +8,7 @@ Tests:
 """
 
 import asyncio
+import contextlib
 import os
 import shutil
 import tempfile
@@ -113,7 +114,8 @@ class ElicitationMultiClientContext:
                 if item.is_dir():
                     shutil.rmtree(item, ignore_errors=True)
                 else:
-                    item.unlink(missing_ok=True)
+                    with contextlib.suppress(OSError):
+                        item.unlink(missing_ok=True)
 
     def _get_env(self) -> dict:
         env = os.environ.copy()

--- a/python/e2e/testharness/context.py
+++ b/python/e2e/testharness/context.py
@@ -4,6 +4,7 @@ Test context for E2E tests.
 Provides isolated directories and a replaying proxy for testing the SDK.
 """
 
+import contextlib
 import os
 import re
 import shutil
@@ -113,18 +114,16 @@ class E2ETestContext:
             await self._proxy.configure(abs_snapshot_path, self.work_dir)
 
         # Clear temp directories between tests (but leave them in place)
-        # Use ignore_errors=True to handle race conditions where files may still
-        # be written by background processes during cleanup
-        for item in Path(self.home_dir).iterdir():
-            if item.is_dir():
-                shutil.rmtree(item, ignore_errors=True)
-            else:
-                item.unlink(missing_ok=True)
-        for item in Path(self.work_dir).iterdir():
-            if item.is_dir():
-                shutil.rmtree(item, ignore_errors=True)
-            else:
-                item.unlink(missing_ok=True)
+        # Use ignore_errors=True / suppress(OSError) to handle race conditions
+        # where files (e.g., SQLite session-store.db on Windows) may still be
+        # held open by a background process during cleanup.
+        for base_dir in (self.home_dir, self.work_dir):
+            for item in Path(base_dir).iterdir():
+                if item.is_dir():
+                    shutil.rmtree(item, ignore_errors=True)
+                else:
+                    with contextlib.suppress(OSError):
+                        item.unlink(missing_ok=True)
 
     def get_env(self) -> dict:
         """Return environment variables configured for isolated testing."""

--- a/python/test_client.py
+++ b/python/test_client.py
@@ -717,6 +717,63 @@ class TestSessionConfigForwarding:
             await client.force_stop()
 
     @pytest.mark.asyncio
+    async def test_resume_session_forwards_continue_pending_work(self):
+        client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH))
+        await client.start()
+
+        try:
+            session = await client.create_session(
+                on_permission_request=PermissionHandler.approve_all
+            )
+
+            captured: dict = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.resume":
+                    return {"sessionId": session.session_id}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await client.resume_session(
+                session.session_id,
+                on_permission_request=PermissionHandler.approve_all,
+                continue_pending_work=True,
+            )
+            assert captured["session.resume"]["continuePendingWork"] is True
+        finally:
+            await client.force_stop()
+
+    @pytest.mark.asyncio
+    async def test_resume_session_omits_continue_pending_work_by_default(self):
+        client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH))
+        await client.start()
+
+        try:
+            session = await client.create_session(
+                on_permission_request=PermissionHandler.approve_all
+            )
+
+            captured: dict = {}
+            original_request = client._client.request
+
+            async def mock_request(method, params):
+                captured[method] = params
+                if method == "session.resume":
+                    return {"sessionId": session.session_id}
+                return await original_request(method, params)
+
+            client._client.request = mock_request
+            await client.resume_session(
+                session.session_id,
+                on_permission_request=PermissionHandler.approve_all,
+            )
+            assert "continuePendingWork" not in captured["session.resume"]
+        finally:
+            await client.force_stop()
+
+    @pytest.mark.asyncio
     async def test_set_model_sends_correct_rpc(self):
         client = CopilotClient(SubprocessConfig(cli_path=CLI_PATH))
         await client.start()

--- a/r/R/client.R
+++ b/r/R/client.R
@@ -386,6 +386,26 @@ CopilotClient <- R6::R6Class(
       invisible(NULL)
     },
 
+    #' @description Get the foreground session ID.
+    #' @return Character or NULL if no foreground session.
+    get_foreground_session_id = function() {
+      if (is.null(private$client)) stop("Client not connected")
+      response <- private$client$request("session.getForeground", list())
+      response$sessionId
+    },
+
+    #' @description Set the foreground session ID.
+    #' @param session_id Character. Session ID to set as foreground.
+    set_foreground_session_id = function(session_id) {
+      if (is.null(private$client)) stop("Client not connected")
+      response <- private$client$request("session.setForeground", list(sessionId = session_id))
+      if (!isTRUE(response$success)) {
+        err <- response$error %||% "Unknown error"
+        stop(paste0("Failed to set foreground session: ", err))
+      }
+      invisible(NULL)
+    },
+
     #' @description Subscribe to session lifecycle events.
     #' @param handler Function(SessionLifecycleEvent).
     #' @return A function that when called, unsubscribes the handler.

--- a/scripts/codegen/csharp.ts
+++ b/scripts/codegen/csharp.ts
@@ -840,7 +840,13 @@ function resolvedResultTypeName(method: RpcMethod): string {
     return resultTypeName(method);
 }
 
-/** Returns the Task<T> or Task string for a method's result type. */
+/** Returns the ValueTask<T> or ValueTask string for an incoming-handler's result type. */
+function handlerTaskType(method: RpcMethod): string {
+    const schema = getMethodResultSchema(method);
+    return !isVoidSchema(schema) ? `ValueTask<${resolvedResultTypeName(method)}>` : "ValueTask";
+}
+
+/** Returns the Task<T> or Task string for an outgoing-call wrapper's result type. */
 function resultTaskType(method: RpcMethod): string {
     const schema = getMethodResultSchema(method);
     return !isVoidSchema(schema) ? `Task<${resolvedResultTypeName(method)}>` : "Task";
@@ -1465,7 +1471,7 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
     lines.push("");
 
     lines.push(`/// <summary>Registers client session API handlers on a JSON-RPC connection.</summary>`);
-    lines.push(`public static class ClientSessionApiRegistration`);
+    lines.push(`internal static class ClientSessionApiRegistration`);
     lines.push(`{`);
     lines.push(`    /// <summary>`);
     lines.push(`    /// Registers handlers for server-to-client session API calls.`);
@@ -1482,11 +1488,10 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
             const hasParams = !!effectiveParams?.properties && Object.keys(effectiveParams.properties).length > 0;
             const resultSchema = getMethodResultSchema(method);
             const paramsClass = paramsTypeName(method);
-            const taskType = resultTaskType(method);
-            const registrationVar = `register${typeToClassName(method.rpcMethod)}Method`;
+            const taskType = handlerTaskType(method);
 
             if (hasParams) {
-                lines.push(`        var ${registrationVar} = (Func<${paramsClass}, CancellationToken, ${taskType}>)(async (request, cancellationToken) =>`);
+                lines.push(`        rpc.SetLocalRpcMethod("${method.rpcMethod}", (Func<${paramsClass}, CancellationToken, ${taskType}>)(async (request, cancellationToken) =>`);
                 lines.push(`        {`);
                 lines.push(`            var handler = getHandlers(request.SessionId).${handlerProperty};`);
                 lines.push(`            if (handler is null) throw new InvalidOperationException($"No ${groupName} handler registered for session: {request.SessionId}");`);
@@ -1495,13 +1500,9 @@ function emitClientSessionApiRegistration(clientSchema: Record<string, unknown>,
                 } else {
                     lines.push(`            await handler.${handlerMethod}(request, cancellationToken);`);
                 }
-                lines.push(`        });`);
-                lines.push(`        rpc.AddLocalRpcMethod(${registrationVar}.Method, ${registrationVar}.Target!, new JsonRpcMethodAttribute("${method.rpcMethod}")`);
-                lines.push(`        {`);
-                lines.push(`            UseSingleObjectParameterDeserialization = true`);
-                lines.push(`        });`);
+                lines.push(`        }), singleObjectParam: true);`);
             } else {
-                lines.push(`        rpc.AddLocalRpcMethod("${method.rpcMethod}", (Func<CancellationToken, ${taskType}>)(_ =>`);
+                lines.push(`        rpc.SetLocalRpcMethod("${method.rpcMethod}", (Func<CancellationToken, ${taskType}>)(_ =>`);
                 lines.push(`            throw new InvalidOperationException("No params provided for ${method.rpcMethod}")));`);
             }
         }
@@ -1544,7 +1545,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using StreamJsonRpc;
 
 namespace GitHub.Copilot.SDK.Rpc;
 

--- a/shell/lib/client.sh
+++ b/shell/lib/client.sh
@@ -406,6 +406,65 @@ copilot_client_list_sessions() {
     return 0
 }
 
+# Get the foreground session ID.
+#
+# Sets:
+#   COPILOT_FOREGROUND_SESSION_ID - The foreground session ID (or empty)
+#   COPILOT_JSONRPC_LAST_RESPONSE - The full response
+#
+# Returns 0 on success, 1 on failure.
+copilot_client_get_foreground_session_id() {
+    _copilot_client_ensure_connected || return 1
+
+    if ! copilot_jsonrpc_request "session.getForeground" "{}"; then
+        echo "ERROR: Failed to get foreground session" >&2
+        return 1
+    fi
+
+    COPILOT_FOREGROUND_SESSION_ID=$(copilot_jsonrpc_get_result_field '.sessionId')
+    if [[ "$COPILOT_FOREGROUND_SESSION_ID" == "null" ]]; then
+        COPILOT_FOREGROUND_SESSION_ID=""
+    fi
+
+    return 0
+}
+
+# Set the foreground session ID.
+#
+# Arguments:
+#   $1 - Session ID to set as foreground (required)
+#
+# Returns 0 on success, 1 on failure.
+copilot_client_set_foreground_session_id() {
+    local session_id="$1"
+
+    _copilot_client_ensure_connected || return 1
+
+    if [[ -z "$session_id" ]]; then
+        echo "ERROR: session_id is required" >&2
+        return 1
+    fi
+
+    local params
+    params=$(jq -c -n --arg sid "$session_id" '{"sessionId":$sid}')
+
+    if ! copilot_jsonrpc_request "session.setForeground" "$params"; then
+        echo "ERROR: Failed to set foreground session $session_id" >&2
+        return 1
+    fi
+
+    local success
+    success=$(copilot_jsonrpc_get_result_field '.success')
+    if [[ "$success" != "true" ]]; then
+        local error_msg
+        error_msg=$(copilot_jsonrpc_get_result_field '.error')
+        echo "ERROR: Failed to set foreground session $session_id: $error_msg" >&2
+        return 1
+    fi
+
+    return 0
+}
+
 # --- Internal Functions ---
 
 # Ensure the client is connected.

--- a/solidity/node_modules/copilot-sdk-supercharged/package-lock.json
+++ b/solidity/node_modules/copilot-sdk-supercharged/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.36-0",
+                "@github/copilot": "^1.0.40-3",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },
@@ -663,26 +663,26 @@
             }
         },
         "node_modules/@github/copilot": {
-            "version": "1.0.36-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.36-0.tgz",
-            "integrity": "sha512-M1mxNbdRkiQv4qApKgV33jK6AsA3TqlMAtKyaDv9sJzE/kZa4IRUAUrmO+3d3C+ojZa/Yffjy0/6dC6kllhI4g==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-3.tgz",
+            "integrity": "sha512-bgvE59bJFsT/tN2CvMR7f5a6NH1tWxYTl9skVrRDk4YS6ZcFP0bclYg/NMDR8D5sfQYngdNN8vxmv85eB8rPVA==",
             "license": "SEE LICENSE IN LICENSE.md",
             "bin": {
                 "copilot": "npm-loader.js"
             },
             "optionalDependencies": {
-                "@github/copilot-darwin-arm64": "1.0.36-0",
-                "@github/copilot-darwin-x64": "1.0.36-0",
-                "@github/copilot-linux-arm64": "1.0.36-0",
-                "@github/copilot-linux-x64": "1.0.36-0",
-                "@github/copilot-win32-arm64": "1.0.36-0",
-                "@github/copilot-win32-x64": "1.0.36-0"
+                "@github/copilot-darwin-arm64": "1.0.40-3",
+                "@github/copilot-darwin-x64": "1.0.40-3",
+                "@github/copilot-linux-arm64": "1.0.40-3",
+                "@github/copilot-linux-x64": "1.0.40-3",
+                "@github/copilot-win32-arm64": "1.0.40-3",
+                "@github/copilot-win32-x64": "1.0.40-3"
             }
         },
         "node_modules/@github/copilot-darwin-arm64": {
-            "version": "1.0.36-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.36-0.tgz",
-            "integrity": "sha512-S0/oT9eo2WvjteWjtjougfh6tokq1Upye6tWeTHWq001E2UvrBN69+cQJNcNQUkO2C2AVvoqiI5RJT/E+HDrww==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-3.tgz",
+            "integrity": "sha512-QRVt15j3azPs8foceUfwT8COnR5DULOhc+5hUp8UgSJagNGEMv8zwVPYoWiJyeApeLdERDeqBF6M6MHHbMjD+A==",
             "cpu": [
                 "arm64"
             ],
@@ -696,9 +696,9 @@
             }
         },
         "node_modules/@github/copilot-darwin-x64": {
-            "version": "1.0.36-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.36-0.tgz",
-            "integrity": "sha512-msY1h6J2j005HMHxYqXO6Q5rJdqAjkUnnBwne5p3s71EHGekOl5U8GJs1Q2Y287+e9ZKSY68ANt/JB0Gq2ivmA==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-3.tgz",
+            "integrity": "sha512-8P2EBAtxjLfk8mG2DR9laWeX6WT4WkrHG+FcTciTNwzRy5YqaFAommwd+nc8I7ddktZvzgQEz8tdM8SAlQ2d2A==",
             "cpu": [
                 "x64"
             ],
@@ -712,9 +712,9 @@
             }
         },
         "node_modules/@github/copilot-linux-arm64": {
-            "version": "1.0.36-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.36-0.tgz",
-            "integrity": "sha512-2yIKaU5XdC0xkFXt80pU+Uqr7pU2lHHzcBehzhDHfDeZVNq8jQj61Ka9r9NBjU3W8c3f99ctPMN8gErFnc5L/A==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-3.tgz",
+            "integrity": "sha512-ItrOgrQ/2QKsrcUHvcSs/y/4HVypzNNFNF/0vL/30yDy89w+5z3hzydZ0uAyMHwf//sWJauAWdkQYmZqaSjT2A==",
             "cpu": [
                 "arm64"
             ],
@@ -728,9 +728,9 @@
             }
         },
         "node_modules/@github/copilot-linux-x64": {
-            "version": "1.0.36-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.36-0.tgz",
-            "integrity": "sha512-tiEnl40MmEc4uybJ8at9TagmEcMsNHDiqzER72PYAD4mKwWklZ3RAClaVgzQlTxn1tMdNM7gbajyqSivLmo+rA==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-3.tgz",
+            "integrity": "sha512-WwRaJeqy+Ywx8XCKH1X/joLK1xbi6MLwWU+ZnRosr8pkvoLnewlBZRVT3dkxkPYvnTIn/PBJKjhtC2lgptbrTg==",
             "cpu": [
                 "x64"
             ],
@@ -744,9 +744,9 @@
             }
         },
         "node_modules/@github/copilot-win32-arm64": {
-            "version": "1.0.36-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.36-0.tgz",
-            "integrity": "sha512-c6hT1lnl7B44tLJGmyugvqPQ51bIMXtTeCb7Z5riPd4Sv17gsU+gLWewJLddAnu+0XhjzlBsIHv9GUtxGPCgWQ==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-3.tgz",
+            "integrity": "sha512-B/JvunL2xFJ6xGLppTehIotaEqEaWOYg+P929rpx90FG2GdsR5oQ5zVHTiMJWX6YFqmW+Kwc5utCMUj7MjDmQQ==",
             "cpu": [
                 "arm64"
             ],
@@ -760,9 +760,9 @@
             }
         },
         "node_modules/@github/copilot-win32-x64": {
-            "version": "1.0.36-0",
-            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.36-0.tgz",
-            "integrity": "sha512-RJy3RtlX+34denR3+ttBZsbyeaGoA2nlYoEtnijsQquK37on4gTwVavRbvjfVa2pL+aMuKhRD+xdvsUd+Fu4Lg==",
+            "version": "1.0.40-3",
+            "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-3.tgz",
+            "integrity": "sha512-80ZFwdKzpRTVjq3MHMU6LjsWjYlVEyI0+rFiM/5s5EmbQDvSnXt4vLT4O+UTbQs+YSi5jRLtm4Q6QkIChE7AWQ==",
             "cpu": [
                 "x64"
             ],
@@ -859,9 +859,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-            "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+            "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
             "cpu": [
                 "arm"
             ],
@@ -873,9 +873,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-            "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+            "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
             "cpu": [
                 "arm64"
             ],
@@ -887,9 +887,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-            "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+            "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
             "cpu": [
                 "arm64"
             ],
@@ -901,9 +901,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-            "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+            "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
             "cpu": [
                 "x64"
             ],
@@ -915,9 +915,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-            "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+            "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
             "cpu": [
                 "arm64"
             ],
@@ -929,9 +929,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-            "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+            "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
             "cpu": [
                 "x64"
             ],
@@ -943,9 +943,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-            "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+            "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
             "cpu": [
                 "arm"
             ],
@@ -957,9 +957,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-            "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+            "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
             "cpu": [
                 "arm"
             ],
@@ -971,9 +971,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-            "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+            "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
             "cpu": [
                 "arm64"
             ],
@@ -985,9 +985,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-            "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+            "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
             "cpu": [
                 "arm64"
             ],
@@ -999,9 +999,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-            "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+            "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
             "cpu": [
                 "loong64"
             ],
@@ -1013,9 +1013,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-            "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+            "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
             "cpu": [
                 "loong64"
             ],
@@ -1027,9 +1027,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-            "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+            "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1041,9 +1041,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-            "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+            "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1055,9 +1055,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-            "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+            "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
             "cpu": [
                 "riscv64"
             ],
@@ -1069,9 +1069,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-            "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+            "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1083,9 +1083,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-            "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+            "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
             "cpu": [
                 "s390x"
             ],
@@ -1097,9 +1097,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-            "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+            "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
             "cpu": [
                 "x64"
             ],
@@ -1111,9 +1111,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-            "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+            "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
             "cpu": [
                 "x64"
             ],
@@ -1125,9 +1125,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-            "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+            "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
             "cpu": [
                 "x64"
             ],
@@ -1139,9 +1139,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-            "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+            "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1153,9 +1153,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-            "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+            "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1167,9 +1167,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-            "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+            "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
             "cpu": [
                 "ia32"
             ],
@@ -1181,9 +1181,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-            "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+            "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
             "cpu": [
                 "x64"
             ],
@@ -1195,9 +1195,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-            "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+            "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
             "cpu": [
                 "x64"
             ],
@@ -1645,9 +1645,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1707,9 +1707,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2275,9 +2275,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -2571,9 +2571,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -2631,9 +2631,9 @@
             }
         },
         "node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-            "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2857,9 +2857,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2880,9 +2880,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "dev": true,
             "funding": [
                 {
@@ -3035,9 +3035,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-            "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+            "version": "4.60.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+            "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3051,31 +3051,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.57.1",
-                "@rollup/rollup-android-arm64": "4.57.1",
-                "@rollup/rollup-darwin-arm64": "4.57.1",
-                "@rollup/rollup-darwin-x64": "4.57.1",
-                "@rollup/rollup-freebsd-arm64": "4.57.1",
-                "@rollup/rollup-freebsd-x64": "4.57.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-                "@rollup/rollup-linux-arm64-musl": "4.57.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-                "@rollup/rollup-linux-loong64-musl": "4.57.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-                "@rollup/rollup-linux-x64-gnu": "4.57.1",
-                "@rollup/rollup-linux-x64-musl": "4.57.1",
-                "@rollup/rollup-openbsd-x64": "4.57.1",
-                "@rollup/rollup-openharmony-arm64": "4.57.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-                "@rollup/rollup-win32-x64-gnu": "4.57.1",
-                "@rollup/rollup-win32-x64-msvc": "4.57.1",
+                "@rollup/rollup-android-arm-eabi": "4.60.2",
+                "@rollup/rollup-android-arm64": "4.60.2",
+                "@rollup/rollup-darwin-arm64": "4.60.2",
+                "@rollup/rollup-darwin-x64": "4.60.2",
+                "@rollup/rollup-freebsd-arm64": "4.60.2",
+                "@rollup/rollup-freebsd-x64": "4.60.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+                "@rollup/rollup-linux-arm64-musl": "4.60.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+                "@rollup/rollup-linux-loong64-musl": "4.60.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+                "@rollup/rollup-linux-x64-gnu": "4.60.2",
+                "@rollup/rollup-linux-x64-musl": "4.60.2",
+                "@rollup/rollup-openbsd-x64": "4.60.2",
+                "@rollup/rollup-openharmony-arm64": "4.60.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+                "@rollup/rollup-win32-x64-gnu": "4.60.2",
+                "@rollup/rollup-win32-x64-msvc": "4.60.2",
                 "fsevents": "~2.3.2"
             }
         },
@@ -3375,9 +3375,9 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3605,9 +3605,9 @@
             "license": "MIT"
         },
         "node_modules/yaml": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "dev": true,
             "license": "ISC",
             "bin": {

--- a/solidity/node_modules/copilot-sdk-supercharged/package.json
+++ b/solidity/node_modules/copilot-sdk-supercharged/package.json
@@ -5,7 +5,7 @@
         "url": "https://github.com/jeremiahjordanisaacson/copilot-sdk-supercharged.git"
     },
     "version": "2.0.0",
-    "description": "GitHub Copilot SDK Supercharged - TypeScript SDK for programmatic control of GitHub Copilot CLI via JSON-RPC. Supports 21 languages.",
+    "description": "GitHub Copilot SDK Supercharged - TypeScript SDK for programmatic control of GitHub Copilot CLI via JSON-RPC. Supports 40 languages.",
     "main": "./dist/cjs/index.js",
     "types": "./dist/index.d.ts",
     "exports": {
@@ -60,7 +60,7 @@
     "author": "jeremiahjordanisaacson",
     "license": "MIT",
     "dependencies": {
-        "@github/copilot": "^1.0.36-0",
+        "@github/copilot": "^1.0.40-3",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
     },

--- a/solidity/node_modules/copilot-sdk-supercharged/samples/package-lock.json
+++ b/solidity/node_modules/copilot-sdk-supercharged/samples/package-lock.json
@@ -18,7 +18,7 @@
             "version": "0.1.8",
             "license": "MIT",
             "dependencies": {
-                "@github/copilot": "^1.0.32",
+                "@github/copilot": "^1.0.40-3",
                 "vscode-jsonrpc": "^8.2.1",
                 "zod": "^4.3.6"
             },

--- a/solidity/node_modules/copilot-sdk-supercharged/src/client.ts
+++ b/solidity/node_modules/copilot-sdk-supercharged/src/client.ts
@@ -911,6 +911,7 @@ export class CopilotClient {
                 disabledSkills: config.disabledSkills,
                 infiniteSessions: config.infiniteSessions,
                 disableResume: config.disableResume,
+                continuePendingWork: config.continuePendingWork,
                 gitHubToken: config.gitHubToken,
             });
 

--- a/solidity/node_modules/copilot-sdk-supercharged/src/generated/rpc.ts
+++ b/solidity/node_modules/copilot-sdk-supercharged/src/generated/rpc.ts
@@ -40,6 +40,42 @@ export type ExtensionSource = "project" | "user";
  * via the `definition` "ExtensionStatus".
  */
 export type ExtensionStatus = "running" | "disabled" | "failed" | "starting";
+/**
+ * Tool call result (string or expanded result object)
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolResult".
+ */
+export type ExternalToolResult = string | ExternalToolTextResultForLlm;
+/**
+ * A content block within a tool result, which may be text, terminal output, image, audio, or a resource
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContent".
+ */
+export type ExternalToolTextResultForLlmContent =
+  | ExternalToolTextResultForLlmContentText
+  | ExternalToolTextResultForLlmContentTerminal
+  | ExternalToolTextResultForLlmContentImage
+  | ExternalToolTextResultForLlmContentAudio
+  | ExternalToolTextResultForLlmContentResourceLink
+  | ExternalToolTextResultForLlmContentResource;
+/**
+ * Theme variant this icon is intended for
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResourceLinkIconTheme".
+ */
+export type ExternalToolTextResultForLlmContentResourceLinkIconTheme = "light" | "dark";
+/**
+ * The embedded resource contents, either text or base64-encoded binary
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResourceDetails".
+ */
+export type ExternalToolTextResultForLlmContentResourceDetails =
+  | EmbeddedTextResourceContents
+  | EmbeddedBlobResourceContents;
 
 export type FilterMapping =
   | {
@@ -87,6 +123,8 @@ export type McpServerConfigLocalType = "local" | "stdio";
  * via the `definition` "McpServerConfigHttpType".
  */
 export type McpServerConfigHttpType = "http" | "sse";
+
+export type McpServerConfigHttpOauthGrantType = "authorization_code" | "client_credentials";
 /**
  * Connection status: connected, failed, needs-auth, pending, disabled, or not_configured
  *
@@ -113,6 +151,7 @@ export type PermissionDecision =
   | PermissionDecisionApproveOnce
   | PermissionDecisionApproveForSession
   | PermissionDecisionApproveForLocation
+  | PermissionDecisionApprovePermanently
   | PermissionDecisionReject
   | PermissionDecisionUserNotAvailable;
 /**
@@ -172,12 +211,42 @@ export type SessionFsSetProviderConventions = "windows" | "posix";
  */
 export type ShellKillSignal = "SIGTERM" | "SIGKILL" | "SIGINT";
 /**
- * Tool call result (string or expanded result object)
+ * Current lifecycle status of the task
  *
  * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
- * via the `definition` "ToolsHandlePendingToolCall".
+ * via the `definition` "TaskAgentInfoStatus".
  */
-export type ToolsHandlePendingToolCall = string | ToolCallResult;
+export type TaskAgentInfoStatus = "running" | "idle" | "completed" | "failed" | "cancelled";
+/**
+ * How the agent is currently being managed by the runtime
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TaskAgentInfoExecutionMode".
+ */
+export type TaskAgentInfoExecutionMode = "sync" | "background";
+
+export type TaskInfo = TaskAgentInfo | TaskShellInfo;
+/**
+ * Current lifecycle status of the task
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TaskShellInfoStatus".
+ */
+export type TaskShellInfoStatus = "running" | "idle" | "completed" | "failed" | "cancelled";
+/**
+ * Whether the shell runs inside a managed PTY session or as an independent background process
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TaskShellInfoAttachmentMode".
+ */
+export type TaskShellInfoAttachmentMode = "attached" | "detached";
+/**
+ * Whether the shell command is currently sync-waited or background-managed
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "TaskShellInfoExecutionMode".
+ */
+export type TaskShellInfoExecutionMode = "sync" | "background";
 
 export type UIElicitationFieldValue = string | number | boolean | string[];
 
@@ -273,6 +342,10 @@ export interface AgentInfo {
    * Description of the agent's purpose
    */
   description: string;
+  /**
+   * Absolute local file path of the agent definition. Only set for file-based agents loaded from disk; remote agents do not have a path.
+   */
+  path?: string;
 }
 
 /** @experimental */
@@ -342,6 +415,36 @@ export interface DiscoveredMcpServer {
   enabled: boolean;
 }
 
+export interface EmbeddedBlobResourceContents {
+  /**
+   * URI identifying the resource
+   */
+  uri: string;
+  /**
+   * MIME type of the blob content
+   */
+  mimeType?: string;
+  /**
+   * Base64-encoded binary content of the resource
+   */
+  blob: string;
+}
+
+export interface EmbeddedTextResourceContents {
+  /**
+   * URI identifying the resource
+   */
+  uri: string;
+  /**
+   * MIME type of the text content
+   */
+  mimeType?: string;
+  /**
+   * Text content of the resource
+   */
+  text: string;
+}
+
 export interface Extension {
   /**
    * Source-qualified ID (e.g., 'project:my-ext', 'user:auth-helper')
@@ -382,6 +485,195 @@ export interface ExtensionsEnableRequest {
    */
   id: string;
 }
+/**
+ * Expanded external tool result payload
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlm".
+ */
+export interface ExternalToolTextResultForLlm {
+  /**
+   * Text result returned to the model
+   */
+  textResultForLlm: string;
+  /**
+   * Execution outcome classification. Optional for back-compat; normalized to 'success' (or 'failure' when error is present) when missing or unrecognized.
+   */
+  resultType?: string;
+  /**
+   * Optional error message for failed executions
+   */
+  error?: string;
+  /**
+   * Detailed log content for timeline display
+   */
+  sessionLog?: string;
+  /**
+   * Optional tool-specific telemetry
+   */
+  toolTelemetry?: {
+    [k: string]: unknown;
+  };
+  /**
+   * Structured content blocks from the tool
+   */
+  contents?: ExternalToolTextResultForLlmContent[];
+  [k: string]: unknown;
+}
+/**
+ * Plain text content block
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentText".
+ */
+export interface ExternalToolTextResultForLlmContentText {
+  /**
+   * Content block type discriminator
+   */
+  type: "text";
+  /**
+   * The text content
+   */
+  text: string;
+}
+/**
+ * Terminal/shell output content block with optional exit code and working directory
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentTerminal".
+ */
+export interface ExternalToolTextResultForLlmContentTerminal {
+  /**
+   * Content block type discriminator
+   */
+  type: "terminal";
+  /**
+   * Terminal/shell output text
+   */
+  text: string;
+  /**
+   * Process exit code, if the command has completed
+   */
+  exitCode?: number;
+  /**
+   * Working directory where the command was executed
+   */
+  cwd?: string;
+}
+/**
+ * Image content block with base64-encoded data
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentImage".
+ */
+export interface ExternalToolTextResultForLlmContentImage {
+  /**
+   * Content block type discriminator
+   */
+  type: "image";
+  /**
+   * Base64-encoded image data
+   */
+  data: string;
+  /**
+   * MIME type of the image (e.g., image/png, image/jpeg)
+   */
+  mimeType: string;
+}
+/**
+ * Audio content block with base64-encoded data
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentAudio".
+ */
+export interface ExternalToolTextResultForLlmContentAudio {
+  /**
+   * Content block type discriminator
+   */
+  type: "audio";
+  /**
+   * Base64-encoded audio data
+   */
+  data: string;
+  /**
+   * MIME type of the audio (e.g., audio/wav, audio/mpeg)
+   */
+  mimeType: string;
+}
+/**
+ * Resource link content block referencing an external resource
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResourceLink".
+ */
+export interface ExternalToolTextResultForLlmContentResourceLink {
+  /**
+   * Icons associated with this resource
+   */
+  icons?: ExternalToolTextResultForLlmContentResourceLinkIcon[];
+  /**
+   * Resource name identifier
+   */
+  name: string;
+  /**
+   * Human-readable display title for the resource
+   */
+  title?: string;
+  /**
+   * URI identifying the resource
+   */
+  uri: string;
+  /**
+   * Human-readable description of the resource
+   */
+  description?: string;
+  /**
+   * MIME type of the resource content
+   */
+  mimeType?: string;
+  /**
+   * Size of the resource in bytes
+   */
+  size?: number;
+  /**
+   * Content block type discriminator
+   */
+  type: "resource_link";
+}
+/**
+ * Icon image for a resource
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResourceLinkIcon".
+ */
+export interface ExternalToolTextResultForLlmContentResourceLinkIcon {
+  /**
+   * URL or path to the icon image
+   */
+  src: string;
+  /**
+   * MIME type of the icon image
+   */
+  mimeType?: string;
+  /**
+   * Available icon sizes (e.g., ['16x16', '32x32'])
+   */
+  sizes?: string[];
+  theme?: ExternalToolTextResultForLlmContentResourceLinkIconTheme;
+}
+/**
+ * Embedded resource content block with inline text or binary data
+ *
+ * This interface was referenced by `_RpcSchemaRoot`'s JSON-Schema
+ * via the `definition` "ExternalToolTextResultForLlmContentResource".
+ */
+export interface ExternalToolTextResultForLlmContentResource {
+  /**
+   * Content block type discriminator
+   */
+  type: "resource";
+  resource: ExternalToolTextResultForLlmContentResourceDetails;
+}
 
 /** @experimental */
 export interface FleetStartRequest {
@@ -399,7 +691,19 @@ export interface FleetStartResult {
   started: boolean;
 }
 
-export interface HandleToolCallResult {
+export interface HandlePendingToolCallRequest {
+  /**
+   * Request ID of the pending tool call
+   */
+  requestId: string;
+  result?: ExternalToolResult;
+  /**
+   * Error message if the tool call failed
+   */
+  error?: string;
+}
+
+export interface HandlePendingToolCallResult {
   /**
    * Whether the tool call result was handled successfully
    */
@@ -576,6 +880,7 @@ export interface McpServerConfigHttp {
   };
   oauthClientId?: string;
   oauthPublicClient?: boolean;
+  oauthGrantType?: McpServerConfigHttpOauthGrantType;
 }
 
 export interface McpConfigDisableRequest {
@@ -901,7 +1206,7 @@ export interface ModeSetRequest {
 
 export interface NameGetResult {
   /**
-   * The session name, falling back to the auto-generated summary, or null if neither exists
+   * The session name (user-set or auto-generated), or null if not yet set
    */
   name: string | null;
 }
@@ -925,7 +1230,11 @@ export interface PermissionDecisionApproveForSession {
    * Approved and remembered for the rest of the session
    */
   kind: "approve-for-session";
-  approval: PermissionDecisionApproveForSessionApproval;
+  approval?: PermissionDecisionApproveForSessionApproval;
+  /**
+   * The URL domain to approve for this session
+   */
+  domain?: string;
 }
 
 export interface PermissionDecisionApproveForSessionApprovalCommands {
@@ -1004,6 +1313,17 @@ export interface PermissionDecisionApproveForLocationApprovalMemory {
 export interface PermissionDecisionApproveForLocationApprovalCustomTool {
   kind: "custom-tool";
   toolName: string;
+}
+
+export interface PermissionDecisionApprovePermanently {
+  /**
+   * Approved and persisted across sessions
+   */
+  kind: "approve-permanently";
+  /**
+   * The URL domain to approve permanently
+   */
+  domain: string;
 }
 
 export interface PermissionDecisionReject {
@@ -1562,6 +1882,205 @@ export interface SkillsEnableRequest {
   name: string;
 }
 
+export interface TaskAgentInfo {
+  /**
+   * Task kind
+   */
+  type: "agent";
+  /**
+   * Unique task identifier
+   */
+  id: string;
+  /**
+   * Tool call ID associated with this agent task
+   */
+  toolCallId: string;
+  /**
+   * Short description of the task
+   */
+  description: string;
+  status: TaskAgentInfoStatus;
+  /**
+   * ISO 8601 timestamp when the task was started
+   */
+  startedAt: string;
+  /**
+   * ISO 8601 timestamp when the task finished
+   */
+  completedAt?: string;
+  /**
+   * Accumulated active execution time in milliseconds
+   */
+  activeTimeMs?: number;
+  /**
+   * ISO 8601 timestamp when the current active period began
+   */
+  activeStartedAt?: string;
+  /**
+   * Error message when the task failed
+   */
+  error?: string;
+  /**
+   * Type of agent running this task
+   */
+  agentType: string;
+  /**
+   * Prompt passed to the agent
+   */
+  prompt: string;
+  /**
+   * Result text from the task when available
+   */
+  result?: string;
+  /**
+   * Model used for the task when specified
+   */
+  model?: string;
+  executionMode?: TaskAgentInfoExecutionMode;
+  /**
+   * Whether the task is currently in the original sync wait and can be moved to background mode. False once it is already backgrounded, idle, finished, or no longer has a promotable sync waiter.
+   */
+  canPromoteToBackground?: boolean;
+  /**
+   * Most recent response text from the agent
+   */
+  latestResponse?: string;
+  /**
+   * ISO 8601 timestamp when the agent entered idle state
+   */
+  idleSince?: string;
+}
+
+export interface TaskShellInfo {
+  /**
+   * Task kind
+   */
+  type: "shell";
+  /**
+   * Unique task identifier
+   */
+  id: string;
+  /**
+   * Short description of the task
+   */
+  description: string;
+  status: TaskShellInfoStatus;
+  /**
+   * ISO 8601 timestamp when the task was started
+   */
+  startedAt: string;
+  /**
+   * ISO 8601 timestamp when the task finished
+   */
+  completedAt?: string;
+  /**
+   * Command being executed
+   */
+  command: string;
+  attachmentMode: TaskShellInfoAttachmentMode;
+  executionMode?: TaskShellInfoExecutionMode;
+  /**
+   * Whether this shell task can be promoted to background mode
+   */
+  canPromoteToBackground?: boolean;
+  /**
+   * Path to the detached shell log, when available
+   */
+  logPath?: string;
+  /**
+   * Process ID when available
+   */
+  pid?: number;
+}
+
+/** @experimental */
+export interface TaskList {
+  /**
+   * Currently tracked tasks
+   */
+  tasks: TaskInfo[];
+}
+
+/** @experimental */
+export interface TasksCancelRequest {
+  /**
+   * Task identifier
+   */
+  id: string;
+}
+
+/** @experimental */
+export interface TasksCancelResult {
+  /**
+   * Whether the task was successfully cancelled
+   */
+  cancelled: boolean;
+}
+
+/** @experimental */
+export interface TasksPromoteToBackgroundRequest {
+  /**
+   * Task identifier
+   */
+  id: string;
+}
+
+/** @experimental */
+export interface TasksPromoteToBackgroundResult {
+  /**
+   * Whether the task was successfully promoted to background mode
+   */
+  promoted: boolean;
+}
+
+/** @experimental */
+export interface TasksRemoveRequest {
+  /**
+   * Task identifier
+   */
+  id: string;
+}
+
+/** @experimental */
+export interface TasksRemoveResult {
+  /**
+   * Whether the task was removed. Returns false if the task does not exist or is still running/idle (cancel it first).
+   */
+  removed: boolean;
+}
+
+/** @experimental */
+export interface TasksStartAgentRequest {
+  /**
+   * Type of agent to start (e.g., 'explore', 'task', 'general-purpose')
+   */
+  agentType: string;
+  /**
+   * Task prompt for the agent
+   */
+  prompt: string;
+  /**
+   * Short name for the agent, used to generate a human-readable ID
+   */
+  name: string;
+  /**
+   * Short description of the task
+   */
+  description?: string;
+  /**
+   * Optional model override
+   */
+  model?: string;
+}
+
+/** @experimental */
+export interface TasksStartAgentResult {
+  /**
+   * Generated agent ID for the background task
+   */
+  agentId: string;
+}
+
 export interface Tool {
   /**
    * Tool identifier (e.g., "bash", "grep", "str_replace_editor")
@@ -1587,44 +2106,11 @@ export interface Tool {
   instructions?: string;
 }
 
-export interface ToolCallResult {
-  /**
-   * Text result to send back to the LLM
-   */
-  textResultForLlm: string;
-  /**
-   * Type of the tool result
-   */
-  resultType?: string;
-  /**
-   * Error message if the tool call failed
-   */
-  error?: string;
-  /**
-   * Telemetry data from tool execution
-   */
-  toolTelemetry?: {
-    [k: string]: unknown;
-  };
-}
-
 export interface ToolList {
   /**
    * List of available built-in tools with metadata
    */
   tools: Tool[];
-}
-
-export interface ToolsHandlePendingToolCallRequest {
-  /**
-   * Request ID of the pending tool call
-   */
-  requestId: string;
-  result?: ToolsHandlePendingToolCall;
-  /**
-   * Error message if the tool call failed
-   */
-  error?: string;
 }
 
 export interface ToolsListRequest {
@@ -1791,6 +2277,16 @@ export interface UsageGetMetricsResult {
    */
   totalUserRequests: number;
   /**
+   * Session-wide accumulated nano-AI units cost
+   */
+  totalNanoAiu?: number;
+  /**
+   * Session-wide per-token-type accumulated token counts
+   */
+  tokenDetails?: {
+    [k: string]: UsageMetricsTokenDetail;
+  };
+  /**
    * Total time spent in model API calls (milliseconds)
    */
   totalApiDurationMs: number;
@@ -1818,6 +2314,13 @@ export interface UsageGetMetricsResult {
    */
   lastCallOutputTokens: number;
 }
+
+export interface UsageMetricsTokenDetail {
+  /**
+   * Accumulated token count for this token type
+   */
+  tokenCount: number;
+}
 /**
  * Aggregated code change metrics
  *
@@ -1842,6 +2345,16 @@ export interface UsageMetricsCodeChanges {
 export interface UsageMetricsModelMetric {
   requests: UsageMetricsModelMetricRequests;
   usage: UsageMetricsModelMetricUsage;
+  /**
+   * Accumulated nano-AI units cost for this model
+   */
+  totalNanoAiu?: number;
+  /**
+   * Token count details per type
+   */
+  tokenDetails?: {
+    [k: string]: UsageMetricsModelMetricTokenDetail;
+  };
 }
 /**
  * Request count and cost metrics for this model
@@ -1888,6 +2401,13 @@ export interface UsageMetricsModelMetricUsage {
   reasoningTokens?: number;
 }
 
+export interface UsageMetricsModelMetricTokenDetail {
+  /**
+   * Accumulated token count for this token type
+   */
+  tokenCount: number;
+}
+
 export interface WorkspacesCreateFileRequest {
   /**
    * Relative path within the workspace files directory
@@ -1910,8 +2430,9 @@ export interface WorkspacesGetWorkspaceResult {
     repository?: string;
     host_type?: "github" | "ado";
     branch?: string;
-    summary?: string;
     name?: string;
+    user_named?: boolean;
+    summary?: string;
     summary_count?: number;
     created_at?: string;
     updated_at?: string;
@@ -2066,6 +2587,19 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 connection.sendRequest("session.agent.reload", { sessionId }),
         },
         /** @experimental */
+        tasks: {
+            startAgent: async (params: TasksStartAgentRequest): Promise<TasksStartAgentResult> =>
+                connection.sendRequest("session.tasks.startAgent", { sessionId, ...params }),
+            list: async (): Promise<TaskList> =>
+                connection.sendRequest("session.tasks.list", { sessionId }),
+            promoteToBackground: async (params: TasksPromoteToBackgroundRequest): Promise<TasksPromoteToBackgroundResult> =>
+                connection.sendRequest("session.tasks.promoteToBackground", { sessionId, ...params }),
+            cancel: async (params: TasksCancelRequest): Promise<TasksCancelResult> =>
+                connection.sendRequest("session.tasks.cancel", { sessionId, ...params }),
+            remove: async (params: TasksRemoveRequest): Promise<TasksRemoveResult> =>
+                connection.sendRequest("session.tasks.remove", { sessionId, ...params }),
+        },
+        /** @experimental */
         skills: {
             list: async (): Promise<SkillList> =>
                 connection.sendRequest("session.skills.list", { sessionId }),
@@ -2109,7 +2643,7 @@ export function createSessionRpc(connection: MessageConnection, sessionId: strin
                 connection.sendRequest("session.extensions.reload", { sessionId }),
         },
         tools: {
-            handlePendingToolCall: async (params: ToolsHandlePendingToolCallRequest): Promise<HandleToolCallResult> =>
+            handlePendingToolCall: async (params: HandlePendingToolCallRequest): Promise<HandlePendingToolCallResult> =>
                 connection.sendRequest("session.tools.handlePendingToolCall", { sessionId, ...params }),
         },
         commands: {

--- a/solidity/node_modules/copilot-sdk-supercharged/src/generated/session-events.ts
+++ b/solidity/node_modules/copilot-sdk-supercharged/src/generated/session-events.ts
@@ -36,6 +36,7 @@ export type SessionEvent =
   | AssistantMessageDeltaEvent
   | AssistantTurnEndEvent
   | AssistantUsageEvent
+  | ModelCallFailureEvent
   | AbortEvent
   | ToolUserRequestedEvent
   | ToolExecutionStartEvent
@@ -122,6 +123,10 @@ export type UserMessageAttachmentGithubReferenceType = "issue" | "pr" | "discuss
  */
 export type AssistantMessageToolRequestType = "function" | "custom";
 /**
+ * Where the failed model call originated
+ */
+export type ModelCallFailureSource = "top_level" | "subagent" | "mcp_sampling";
+/**
  * A content block within a tool result, which may be text, terminal output, image, audio, or a resource
  */
 export type ToolExecutionCompleteContent =
@@ -151,7 +156,8 @@ export type SystemNotification =
   | SystemNotificationAgentIdle
   | SystemNotificationNewInboxMessage
   | SystemNotificationShellCompleted
-  | SystemNotificationShellDetachedCompleted;
+  | SystemNotificationShellDetachedCompleted
+  | SystemNotificationInstructionDiscovered;
 /**
  * Whether the agent completed successfully or failed
  */
@@ -202,17 +208,28 @@ export type PermissionPromptRequestMemoryDirection = "upvote" | "downvote";
  */
 export type PermissionPromptRequestPathAccessKind = "read" | "shell" | "write";
 /**
- * The outcome of the permission request
+ * The result of the permission request
  */
-export type PermissionCompletedKind =
-  | "approved"
-  | "approved-for-session"
-  | "approved-for-location"
-  | "denied-by-rules"
-  | "denied-no-approval-rule-and-could-not-request-from-user"
-  | "denied-interactively-by-user"
-  | "denied-by-content-exclusion-policy"
-  | "denied-by-permission-request-hook";
+export type PermissionResult =
+  | PermissionApproved
+  | PermissionApprovedForSession
+  | PermissionApprovedForLocation
+  | PermissionCancelled
+  | PermissionDeniedByRules
+  | PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser
+  | PermissionDeniedInteractivelyByUser
+  | PermissionDeniedByContentExclusionPolicy
+  | PermissionDeniedByPermissionRequestHook;
+/**
+ * The approval to add as a session-scoped rule
+ */
+export type UserToolSessionApproval =
+  | UserToolSessionApprovalCommands
+  | UserToolSessionApprovalRead
+  | UserToolSessionApprovalWrite
+  | UserToolSessionApprovalMcp
+  | UserToolSessionApprovalMemory
+  | UserToolSessionApprovalCustomTool;
 /**
  * Elicitation mode; "form" for structured input, "url" for browser-based. Defaults to "form" when absent.
  */
@@ -385,6 +402,10 @@ export interface ResumeData {
   alreadyInUse?: boolean;
   context?: WorkingDirectoryContext;
   /**
+   * When true, tool calls and permission requests left in flight by the previous session lifetime remain pending after resume and the agentic loop awaits their results. User sends are queued behind the pending work until all such requests reach a terminal state. When false (the default), any such tool calls and permission requests are immediately marked as interrupted on resume.
+   */
+  continuePendingWork?: boolean;
+  /**
    * Total number of persisted events in the session at the time of resume
    */
   eventCount: number;
@@ -404,6 +425,10 @@ export interface ResumeData {
    * Model currently selected at resume time
    */
   selectedModel?: string;
+  /**
+   * True when this resume attached to a session that the runtime already had running in-memory (for example, an extension joining a session another client was actively driving). False (or omitted) for cold resumes — the runtime had to reconstitute the session from its persisted event log.
+   */
+  sessionWasActive?: boolean;
 }
 export interface RemoteSteerableChangedEvent {
   /**
@@ -466,6 +491,14 @@ export interface ErrorEvent {
  * Error details for timeline display including message and optional diagnostic information
  */
 export interface ErrorData {
+  /**
+   * Only set on `errorType: "rate_limit"`. When `true`, the runtime will follow this error with an `auto_mode_switch.requested` event (or silently switch if `continueOnAutoMode` is enabled). UI clients can use this flag to suppress duplicate rendering of the rate-limit error when they show their own auto-mode-switch prompt.
+   */
+  eligibleForAutoSwitch?: boolean;
+  /**
+   * Fine-grained error code from the upstream provider, when available. For `errorType: "rate_limit"`, this is one of the `RateLimitErrorCode` values (e.g., `"user_weekly_rate_limited"`, `"user_global_rate_limited"`, `"rate_limited"`, `"user_model_rate_limited"`, `"integration_rate_limited"`).
+   */
+  errorCode?: string;
   /**
    * Category of error (e.g., "authentication", "authorization", "quota", "rate_limit", "context_limit", "query")
    */
@@ -588,6 +621,10 @@ export interface InfoData {
    */
   message: string;
   /**
+   * Optional actionable tip displayed with this message
+   */
+  tip?: string;
+  /**
    * Optional URL associated with this message that the user can open in a browser
    */
   url?: string;
@@ -661,6 +698,10 @@ export interface ModelChangeEvent {
  * Model change details including previous and new model identifiers
  */
 export interface ModelChangeData {
+  /**
+   * Reason the change happened, when not user-initiated. Currently `"rate_limit_auto_switch"` for changes triggered by the auto-mode-switch rate-limit recovery path. UI clients can use this to render contextual copy.
+   */
+  cause?: string;
   /**
    * Newly selected model identifier
    */
@@ -1003,6 +1044,12 @@ export interface ShutdownData {
    */
   systemTokens?: number;
   /**
+   * Session-wide per-token-type accumulated token counts
+   */
+  tokenDetails?: {
+    [k: string]: ShutdownTokenDetail;
+  };
+  /**
    * Tool definitions token count at shutdown
    */
   toolDefinitionsTokens?: number;
@@ -1010,6 +1057,10 @@ export interface ShutdownData {
    * Cumulative time spent in API calls during the session, in milliseconds
    */
   totalApiDurationMs: number;
+  /**
+   * Session-wide accumulated nano-AI units cost
+   */
+  totalNanoAiu?: number;
   /**
    * Total number of premium API requests used during the session
    */
@@ -1034,6 +1085,16 @@ export interface ShutdownCodeChanges {
 }
 export interface ShutdownModelMetric {
   requests: ShutdownModelMetricRequests;
+  /**
+   * Token count details per type
+   */
+  tokenDetails?: {
+    [k: string]: ShutdownModelMetricTokenDetail;
+  };
+  /**
+   * Accumulated nano-AI units cost for this model
+   */
+  totalNanoAiu?: number;
   usage: ShutdownModelMetricUsage;
 }
 /**
@@ -1048,6 +1109,12 @@ export interface ShutdownModelMetricRequests {
    * Total number of API requests made to this model
    */
   count: number;
+}
+export interface ShutdownModelMetricTokenDetail {
+  /**
+   * Accumulated token count for this token type
+   */
+  tokenCount: number;
 }
 /**
  * Token usage breakdown
@@ -1073,6 +1140,12 @@ export interface ShutdownModelMetricUsage {
    * Total reasoning tokens produced across all requests to this model
    */
   reasoningTokens?: number;
+}
+export interface ShutdownTokenDetail {
+  /**
+   * Accumulated token count for this token type
+   */
+  tokenCount: number;
 }
 export interface ContextChangedEvent {
   /**
@@ -1318,7 +1391,7 @@ export interface CompactionCompleteCompactionTokensUsedCopilotUsage {
    */
   tokenDetails: CompactionCompleteCompactionTokensUsedCopilotUsageTokenDetail[];
   /**
-   * Total cost in nano-AIU (AI Units) for this request
+   * Total cost in nano-AI units for this request
    */
   totalNanoAiu: number;
 }
@@ -1422,6 +1495,10 @@ export interface UserMessageData {
    * Path-backed native document attachments that stayed on the tagged_files path flow because native upload would exceed the request size limit
    */
   nativeDocumentPathFallbackPaths?: string[];
+  /**
+   * Parent agent task ID for background telemetry correlated to this user turn
+   */
+  parentAgentTaskId?: string;
   /**
    * Origin of this message, used for timeline filtering (e.g., "skill-pdf" for skill-injected messages that should be hidden from the user)
    */
@@ -1851,6 +1928,10 @@ export interface AssistantMessageData {
    * Tool invocations requested by the assistant in this message
    */
   toolRequests?: AssistantMessageToolRequest[];
+  /**
+   * Identifier for the agent loop turn that produced this message, matching the corresponding assistant.turn_start event
+   */
+  turnId?: string;
 }
 /**
  * A tool invocation request from the assistant
@@ -2059,7 +2140,7 @@ export interface AssistantUsageCopilotUsage {
    */
   tokenDetails: AssistantUsageCopilotUsageTokenDetail[];
   /**
-   * Total cost in nano-AIU (AI Units) for this request
+   * Total cost in nano-AI units for this request
    */
   totalNanoAiu: number;
 }
@@ -2117,6 +2198,61 @@ export interface AssistantUsageQuotaSnapshot {
    * Number of requests already consumed
    */
   usedRequests: number;
+}
+export interface ModelCallFailureEvent {
+  /**
+   * Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.
+   */
+  agentId?: string;
+  data: ModelCallFailureData;
+  ephemeral: true;
+  /**
+   * Unique event identifier (UUID v4), generated when the event is emitted
+   */
+  id: string;
+  /**
+   * ID of the chronologically preceding event in the session, forming a linked chain. Null for the first event.
+   */
+  parentId: string | null;
+  /**
+   * ISO 8601 timestamp when the event was created
+   */
+  timestamp: string;
+  type: "model.call_failure";
+}
+/**
+ * Failed LLM API call metadata for telemetry
+ */
+export interface ModelCallFailureData {
+  /**
+   * Completion ID from the model provider (e.g., chatcmpl-abc123)
+   */
+  apiCallId?: string;
+  /**
+   * Duration of the failed API call in milliseconds
+   */
+  durationMs?: number;
+  /**
+   * Raw provider/runtime error message for restricted telemetry
+   */
+  errorMessage?: string;
+  /**
+   * What initiated this API call (e.g., "sub-agent", "mcp-sampling"); absent for user-initiated calls
+   */
+  initiator?: string;
+  /**
+   * Model identifier used for the failed API call
+   */
+  model?: string;
+  /**
+   * GitHub request tracing ID (x-github-request-id header) for server-side log correlation
+   */
+  providerCallId?: string;
+  source: ModelCallFailureSource;
+  /**
+   * HTTP status code from the failed request
+   */
+  statusCode?: number;
 }
 export interface AbortEvent {
   /**
@@ -2249,6 +2385,10 @@ export interface ToolExecutionStartData {
    * Name of the tool being executed
    */
   toolName: string;
+  /**
+   * Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event
+   */
+  turnId?: string;
 }
 export interface ToolExecutionPartialResultEvent {
   /**
@@ -2379,6 +2519,10 @@ export interface ToolExecutionCompleteData {
   toolTelemetry?: {
     [k: string]: unknown;
   };
+  /**
+   * Identifier for the agent loop turn this tool was invoked in, matching the corresponding assistant.turn_start event
+   */
+  turnId?: string;
 }
 /**
  * Error details when the tool execution failed
@@ -3097,7 +3241,7 @@ export interface SystemNotificationNewInboxMessage {
    */
   senderName: string;
   /**
-   * Category of the sender (e.g., ambient-agent, plugin, hook)
+   * Category of the sender (e.g., sidekick-agent, plugin, hook)
    */
   senderType: string;
   /**
@@ -3132,13 +3276,35 @@ export interface SystemNotificationShellDetachedCompleted {
   shellId: string;
   type: "shell_detached_completed";
 }
+export interface SystemNotificationInstructionDiscovered {
+  /**
+   * Human-readable label for the timeline (e.g., 'AGENTS.md from packages/billing/')
+   */
+  description?: string;
+  /**
+   * Relative path to the discovered instruction file
+   */
+  sourcePath: string;
+  /**
+   * Path of the file access that triggered discovery
+   */
+  triggerFile: string;
+  /**
+   * Tool command that triggered discovery (currently always 'view')
+   */
+  triggerTool: string;
+  type: "instruction_discovered";
+}
 export interface PermissionRequestedEvent {
   /**
    * Sub-agent instance identifier. Absent for events from the root/main agent and session-level events.
    */
   agentId?: string;
   data: PermissionRequestedData;
-  ephemeral: true;
+  /**
+   * When true, the event is transient and not persisted to the session event log on disk
+   */
+  ephemeral?: boolean;
   /**
    * Unique event identifier (UUID v4), generated when the event is emitted
    */
@@ -3667,7 +3833,10 @@ export interface PermissionCompletedEvent {
    */
   agentId?: string;
   data: PermissionCompletedData;
-  ephemeral: true;
+  /**
+   * When true, the event is transient and not persisted to the session event log on disk
+   */
+  ephemeral?: boolean;
   /**
    * Unique event identifier (UUID v4), generated when the event is emitted
    */
@@ -3690,17 +3859,165 @@ export interface PermissionCompletedData {
    * Request ID of the resolved permission request; clients should dismiss any UI for this request
    */
   requestId: string;
-  result: PermissionCompletedResult;
+  result: PermissionResult;
   /**
    * Optional tool call ID associated with this permission prompt; clients may use it to correlate UI created from tool-scoped prompts
    */
   toolCallId?: string;
 }
-/**
- * The result of the permission request
- */
-export interface PermissionCompletedResult {
-  kind: PermissionCompletedKind;
+export interface PermissionApproved {
+  /**
+   * The permission request was approved
+   */
+  kind: "approved";
+}
+export interface PermissionApprovedForSession {
+  approval: UserToolSessionApproval;
+  /**
+   * Approved and remembered for the rest of the session
+   */
+  kind: "approved-for-session";
+}
+export interface UserToolSessionApprovalCommands {
+  /**
+   * Command identifiers approved by the user
+   */
+  commandIdentifiers: string[];
+  /**
+   * Command approval kind
+   */
+  kind: "commands";
+}
+export interface UserToolSessionApprovalRead {
+  /**
+   * Read approval kind
+   */
+  kind: "read";
+}
+export interface UserToolSessionApprovalWrite {
+  /**
+   * Write approval kind
+   */
+  kind: "write";
+}
+export interface UserToolSessionApprovalMcp {
+  /**
+   * MCP tool approval kind
+   */
+  kind: "mcp";
+  /**
+   * MCP server name
+   */
+  serverName: string;
+  /**
+   * Optional MCP tool name, or null for all tools on the server
+   */
+  toolName: string | null;
+}
+export interface UserToolSessionApprovalMemory {
+  /**
+   * Memory approval kind
+   */
+  kind: "memory";
+}
+export interface UserToolSessionApprovalCustomTool {
+  /**
+   * Custom tool approval kind
+   */
+  kind: "custom-tool";
+  /**
+   * Custom tool name
+   */
+  toolName: string;
+}
+export interface PermissionApprovedForLocation {
+  approval: UserToolSessionApproval;
+  /**
+   * Approved and persisted for this project location
+   */
+  kind: "approved-for-location";
+  /**
+   * The location key (git root or cwd) to persist the approval to
+   */
+  locationKey: string;
+}
+export interface PermissionCancelled {
+  /**
+   * The permission request was cancelled before a response was used
+   */
+  kind: "cancelled";
+  /**
+   * Optional explanation of why the request was cancelled
+   */
+  reason?: string;
+}
+export interface PermissionDeniedByRules {
+  /**
+   * Denied because approval rules explicitly blocked it
+   */
+  kind: "denied-by-rules";
+  /**
+   * Rules that denied the request
+   */
+  rules: PermissionRule[];
+}
+export interface PermissionRule {
+  /**
+   * Optional rule argument matched against the request
+   */
+  argument: string | null;
+  /**
+   * The rule kind, such as Shell or GitHubMCP
+   */
+  kind: string;
+}
+export interface PermissionDeniedNoApprovalRuleAndCouldNotRequestFromUser {
+  /**
+   * Denied because no approval rule matched and user confirmation was unavailable
+   */
+  kind: "denied-no-approval-rule-and-could-not-request-from-user";
+}
+export interface PermissionDeniedInteractivelyByUser {
+  /**
+   * Optional feedback from the user explaining the denial
+   */
+  feedback?: string;
+  /**
+   * Whether to force-reject the current agent turn
+   */
+  forceReject?: boolean;
+  /**
+   * Denied by the user during an interactive prompt
+   */
+  kind: "denied-interactively-by-user";
+}
+export interface PermissionDeniedByContentExclusionPolicy {
+  /**
+   * Denied by the organization's content exclusion policy
+   */
+  kind: "denied-by-content-exclusion-policy";
+  /**
+   * Human-readable explanation of why the path was excluded
+   */
+  message: string;
+  /**
+   * File path that triggered the exclusion
+   */
+  path: string;
+}
+export interface PermissionDeniedByPermissionRequestHook {
+  /**
+   * Whether to interrupt the current agent turn
+   */
+  interrupt?: boolean;
+  /**
+   * Denied by a permission request hook registered by an extension or plugin
+   */
+  kind: "denied-by-permission-request-hook";
+  /**
+   * Optional message from the hook explaining the denial
+   */
+  message?: string;
 }
 export interface UserInputRequestedEvent {
   /**
@@ -4008,6 +4325,10 @@ export interface McpOauthRequiredStaticClientConfig {
    */
   clientId: string;
   /**
+   * Optional non-default OAuth grant type. When set to 'client_credentials', the OAuth flow runs headlessly using the client_id + keychain-stored secret (no browser, no callback server).
+   */
+  grantType?: "client_credentials";
+  /**
    * Whether this is a public OAuth client
    */
   publicClient?: boolean;
@@ -4048,7 +4369,10 @@ export interface ExternalToolRequestedEvent {
    */
   agentId?: string;
   data: ExternalToolRequestedData;
-  ephemeral: true;
+  /**
+   * When true, the event is transient and not persisted to the session event log on disk
+   */
+  ephemeral?: boolean;
   /**
    * Unique event identifier (UUID v4), generated when the event is emitted
    */
@@ -4104,7 +4428,7 @@ export interface ExternalToolCompletedEvent {
    */
   agentId?: string;
   data: ExternalToolCompletedData;
-  ephemeral: true;
+  ephemeral?: true;
   /**
    * Unique event identifier (UUID v4), generated when the event is emitted
    */
@@ -4267,6 +4591,10 @@ export interface AutoModeSwitchRequestedData {
    * Unique identifier for this request; used to respond via session.respondToAutoModeSwitch()
    */
   requestId: string;
+  /**
+   * Seconds until the rate limit resets, when known. Lets clients render a humanized reset time alongside the prompt.
+   */
+  retryAfterSeconds?: number;
 }
 export interface AutoModeSwitchCompletedEvent {
   /**

--- a/solidity/node_modules/copilot-sdk-supercharged/src/types.ts
+++ b/solidity/node_modules/copilot-sdk-supercharged/src/types.ts
@@ -1421,6 +1421,18 @@ export type ResumeSessionConfig = Pick<
      * @default false
      */
     disableResume?: boolean;
+    /**
+     * When true, the runtime continues any tool calls or permission prompts that were
+     * still pending when the session was last suspended. When false (the default), the
+     * runtime treats pending work as interrupted on resume.
+     *
+     * For permission requests, the runtime re-emits `permission.requested` so the
+     * registered `onPermissionRequest` handler can re-prompt; for external tool calls,
+     * the consumer is expected to supply the result via the corresponding low-level
+     * RPC method.
+     * @default false
+     */
+    continuePendingWork?: boolean;
 };
 
 /**

--- a/solidity/node_modules/copilot-sdk-supercharged/test/client.test.ts
+++ b/solidity/node_modules/copilot-sdk-supercharged/test/client.test.ts
@@ -166,6 +166,47 @@ describe("CopilotClient", () => {
         spy.mockRestore();
     });
 
+    it("forwards continuePendingWork in session.resume request", async () => {
+        const client = new CopilotClient();
+        await client.start();
+        onTestFinished(() => client.forceStop());
+
+        const session = await client.createSession({ onPermissionRequest: approveAll });
+        const spy = vi
+            .spyOn((client as any).connection!, "sendRequest")
+            .mockImplementation(async (method: string, params: any) => {
+                if (method === "session.resume") return { sessionId: params.sessionId };
+                throw new Error(`Unexpected method: ${method}`);
+            });
+        await client.resumeSession(session.sessionId, {
+            onPermissionRequest: approveAll,
+            continuePendingWork: true,
+        });
+
+        const payload = spy.mock.calls.find((c) => c[0] === "session.resume")![1] as any;
+        expect(payload.continuePendingWork).toBe(true);
+        spy.mockRestore();
+    });
+
+    it("omits continuePendingWork from session.resume payload when not specified", async () => {
+        const client = new CopilotClient();
+        await client.start();
+        onTestFinished(() => client.forceStop());
+
+        const session = await client.createSession({ onPermissionRequest: approveAll });
+        const spy = vi
+            .spyOn((client as any).connection!, "sendRequest")
+            .mockImplementation(async (method: string, params: any) => {
+                if (method === "session.resume") return { sessionId: params.sessionId };
+                throw new Error(`Unexpected method: ${method}`);
+            });
+        await client.resumeSession(session.sessionId, { onPermissionRequest: approveAll });
+
+        const payload = spy.mock.calls.find((c) => c[0] === "session.resume")![1] as any;
+        expect(payload.continuePendingWork).toBeUndefined();
+        spy.mockRestore();
+    });
+
     it("forwards provider headers in session.create request", async () => {
         const client = new CopilotClient();
         await client.start();

--- a/solidity/node_modules/copilot-sdk-supercharged/test/e2e/harness/sdkTestContext.ts
+++ b/solidity/node_modules/copilot-sdk-supercharged/test/e2e/harness/sdkTestContext.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from "url";
 import { afterAll, afterEach, beforeEach, onTestFailed, TestContext } from "vitest";
 import { CopilotClient, CopilotClientOptions } from "../../../src";
 import { CapiProxy } from "./CapiProxy";
-import { retry } from "./sdkTestHelper";
+import { retry, formatError } from "./sdkTestHelper";
 
 export const isCI = process.env.GITHUB_ACTIONS === "true";
 
@@ -30,6 +30,7 @@ export async function createSdkTestContext({
     copilotClientOptions?: CopilotClientOptions;
 } = {}) {
     const homeDir = realpathSync(fs.mkdtempSync(join(os.tmpdir(), "copilot-test-config-")));
+    const copilotHomeDir = realpathSync(fs.mkdtempSync(join(os.tmpdir(), "copilot-test-home-")));
     const workDir = realpathSync(fs.mkdtempSync(join(os.tmpdir(), "copilot-test-work-")));
 
     const openAiEndpoint = new CapiProxy();
@@ -37,6 +38,7 @@ export async function createSdkTestContext({
     const env = {
         ...process.env,
         COPILOT_API_URL: proxyUrl,
+        COPILOT_HOME: copilotHomeDir,
 
         // TODO: I'm not convinced the SDK should default to using whatever config you happen to have in your homedir.
         // The SDK config should be independent of the regular CLI app. Likewise it shouldn't mix sessions from the
@@ -86,6 +88,7 @@ export async function createSdkTestContext({
     afterAll(async () => {
         await copilotClient.stop();
         await openAiEndpoint.stop(anyTestFailed);
+        await rmDir("remove e2e test copilotHomeDir", copilotHomeDir);
         await rmDir("remove e2e test homeDir", homeDir);
         await rmDir("remove e2e test workDir", workDir);
     });
@@ -108,6 +111,17 @@ function getTrafficCapturePath(testContext: TestContext): string {
     return join(SNAPSHOTS_DIR, testFileName, `${taskNameAsFilename}.yaml`);
 }
 
-function rmDir(message: string, path: string): Promise<void> {
-    return retry(message, () => rm(path, { recursive: true, force: true }), 5, 2000);
+async function rmDir(message: string, path: string): Promise<void> {
+    // Use longer retries to tolerate Windows holding SQLite session-store.db
+    // open briefly after the CLI subprocess exits. If the temp dir still can't
+    // be removed (e.g. CLI background writer racing with cleanup), warn and
+    // continue rather than failing the whole test run — the OS / CI runner
+    // will reclaim the temp dir on shutdown.
+    try {
+        await retry(message, () => rm(path, { recursive: true, force: true }), 30, 1000);
+    } catch (error) {
+        console.warn(
+            `WARN: ${message} failed; leaving temp dir for OS cleanup: ${formatError(error)}`
+        );
+    }
 }

--- a/solidity/node_modules/copilot-sdk-supercharged/test/e2e/session_fs.test.ts
+++ b/solidity/node_modules/copilot-sdk-supercharged/test/e2e/session_fs.test.ts
@@ -4,6 +4,9 @@
 
 import { SessionCompactionCompleteEvent } from "@github/copilot/sdk";
 import { MemoryProvider, VirtualProvider } from "@platformatic/vfs";
+import { mkdtempSync, realpathSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { CopilotClient } from "../../src/client.js";
 import type { SessionFsReaddirWithTypesEntry } from "../../src/generated/rpc.js";
@@ -17,6 +20,14 @@ import {
     type SessionFsFileInfo,
 } from "../../src/index.js";
 import { createSdkTestContext } from "./harness/sdkTestContext.js";
+
+const sessionStatePath =
+    process.platform === "win32"
+        ? "/session-state"
+        : join(
+              realpathSync(mkdtempSync(join(tmpdir(), "copilot-sessionfs-state-"))),
+              "session-state"
+          ).replace(/\\/g, "/");
 
 describe("Session Fs", async () => {
     // Single provider for the describe block — session IDs are unique per test,
@@ -43,7 +54,9 @@ describe("Session Fs", async () => {
         expect(msg?.data.content).toContain("300");
         await session.disconnect();
 
-        const buf = await provider.readFile(p(session.sessionId, "/session-state/events.jsonl"));
+        const buf = await provider.readFile(
+            p(session.sessionId, `${sessionStatePath}/events.jsonl`)
+        );
         const content = buf.toString("utf8");
         expect(content).toContain("300");
     });
@@ -60,7 +73,7 @@ describe("Session Fs", async () => {
         await session1.disconnect();
 
         // The events file should exist before resume
-        expect(await provider.exists(p(sessionId, "/session-state/events.jsonl"))).toBe(true);
+        expect(await provider.exists(p(sessionId, `${sessionStatePath}/events.jsonl`))).toBe(true);
 
         const session2 = await client.resumeSession(sessionId, {
             onPermissionRequest: approveAll,
@@ -116,8 +129,10 @@ describe("Session Fs", async () => {
         // The tool result should reference a temp file under the session state path
         const messages = await session.getMessages();
         const toolResult = findToolCallResult(messages, "get_big_string");
-        expect(toolResult).toContain("/session-state/temp/");
-        const filename = toolResult?.match(/(\/session-state\/temp\/[^\s]+)/)?.[1];
+        expect(toolResult).toContain(`${sessionStatePath}/temp/`);
+        const filename = toolResult?.match(
+            new RegExp(`(${escapeRegExp(sessionStatePath)}/temp/[^\\s]+)`)
+        )?.[1];
         expect(filename).toBeDefined();
 
         // Verify the file was written with the correct content via the provider
@@ -135,13 +150,13 @@ describe("Session Fs", async () => {
         expect(msg?.data.content).toContain("56");
 
         // WorkspaceManager should have created workspace.yaml via sessionFs
-        const workspaceYamlPath = p(session.sessionId, "/session-state/workspace.yaml");
+        const workspaceYamlPath = p(session.sessionId, `${sessionStatePath}/workspace.yaml`);
         await expect.poll(() => provider.exists(workspaceYamlPath)).toBe(true);
         const yaml = await provider.readFile(workspaceYamlPath, "utf8");
         expect(yaml).toContain("id:");
 
         // Checkpoint index should also exist
-        const indexPath = p(session.sessionId, "/session-state/checkpoints/index.md");
+        const indexPath = p(session.sessionId, `${sessionStatePath}/checkpoints/index.md`);
         await expect.poll(() => provider.exists(indexPath)).toBe(true);
 
         await session.disconnect();
@@ -157,7 +172,7 @@ describe("Session Fs", async () => {
         await session.sendAndWait({ prompt: "What is 2 + 3?" });
         await session.rpc.plan.update({ content: "# Test Plan\n\nThis is a test." });
 
-        const planPath = p(session.sessionId, "/session-state/plan.md");
+        const planPath = p(session.sessionId, `${sessionStatePath}/plan.md`);
         await expect.poll(() => provider.exists(planPath)).toBe(true);
         const content = await provider.readFile(planPath, "utf8");
         expect(content).toContain("# Test Plan");
@@ -176,7 +191,7 @@ describe("Session Fs", async () => {
 
         await session.sendAndWait({ prompt: "What is 2+2?" });
 
-        const eventsPath = p(session.sessionId, "/session-state/events.jsonl");
+        const eventsPath = p(session.sessionId, `${sessionStatePath}/events.jsonl`);
         await expect.poll(() => provider.exists(eventsPath)).toBe(true);
         const contentBefore = await provider.readFile(eventsPath, "utf8");
         expect(contentBefore).not.toContain("checkpointNumber");
@@ -212,9 +227,13 @@ function findToolName(messages: SessionEvent[], toolCallId: string): string | un
 
 const sessionFsConfig: SessionFsConfig = {
     initialCwd: "/",
-    sessionStatePath: "/session-state",
+    sessionStatePath,
     conventions: "posix",
 };
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function createTestSessionFsHandler(
     session: CopilotSession,

--- a/solidity/src/client.ts
+++ b/solidity/src/client.ts
@@ -91,6 +91,20 @@ export class CopilotSolidityClient {
     }
 
     // -----------------------------------------------------------------------
+    // Foreground session management
+    // -----------------------------------------------------------------------
+
+    /** Get the foreground session ID from the CLI server. */
+    async getForegroundSessionId(): Promise<string> {
+        return (this.client as any).getForegroundSessionId();
+    }
+
+    /** Set the foreground session ID on the CLI server. */
+    async setForegroundSessionId(sessionId: string): Promise<void> {
+        return (this.client as any).setForegroundSessionId(sessionId);
+    }
+
+    // -----------------------------------------------------------------------
     // Session helpers
     // -----------------------------------------------------------------------
 

--- a/tcl/lib/copilot/client.tcl
+++ b/tcl/lib/copilot/client.tcl
@@ -362,6 +362,56 @@ proc ::copilot::client::get_auth_status {handle} {
     return $result
 }
 
+# ---- Get foreground session ID ----------------------------------------------
+
+proc ::copilot::client::get_foreground_session_id {handle} {
+    variable clients
+    if {![dict exists $clients $handle]} {
+        error "Client not found: $handle"
+    }
+
+    set cdata [dict get $clients $handle]
+    set write_ch [dict get $cdata write_ch]
+    set read_ch  [dict get $cdata read_ch]
+
+    set req_id [::copilot::jsonrpc::send_request $write_ch "session.getForeground" [dict create]]
+    ::copilot::jsonrpc::register_pending $req_id
+
+    set result [::copilot::session::_wait_for_response $read_ch $write_ch $req_id]
+
+    if {[dict exists $result sessionId]} {
+        return [dict get $result sessionId]
+    }
+    error "No sessionId in response"
+}
+
+# ---- Set foreground session ID ----------------------------------------------
+
+proc ::copilot::client::set_foreground_session_id {handle session_id} {
+    variable clients
+    if {![dict exists $clients $handle]} {
+        error "Client not found: $handle"
+    }
+
+    set cdata [dict get $clients $handle]
+    set write_ch [dict get $cdata write_ch]
+    set read_ch  [dict get $cdata read_ch]
+
+    set params [dict create sessionId $session_id]
+    set req_id [::copilot::jsonrpc::send_request $write_ch "session.setForeground" $params]
+    ::copilot::jsonrpc::register_pending $req_id
+
+    set result [::copilot::session::_wait_for_response $read_ch $write_ch $req_id]
+
+    if {![dict exists $result success] || ![dict get $result success]} {
+        set err_msg "Unknown"
+        if {[dict exists $result error]} {
+            set err_msg [dict get $result error]
+        }
+        error "Failed to set foreground session: $err_msg"
+    }
+}
+
 # ---- Get connection state ---------------------------------------------------
 
 proc ::copilot::client::get_state {handle} {

--- a/test/harness/package-lock.json
+++ b/test/harness/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@github/copilot": "^1.0.40-0",
+        "@github/copilot": "^1.0.40-1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@types/node": "^25.3.3",
         "openai": "^6.17.0",
@@ -462,27 +462,27 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.40-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-0.tgz",
-      "integrity": "sha512-KIrRqPOCGPcYUq09wvi66qUi5YMFTH5z9fOEzo1BuyLFVQqUen0TtRk0mpbhG6TxArLPqosBY8nDXOdc+NqKKw==",
+      "version": "1.0.40-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-1.tgz",
+      "integrity": "sha512-jdohe7CcjlmbNR0bnL/uAbaYDtmqZnHcHo3t/ZspVb9vo7+yk7AdTc4AF4TpV7M/tCKc+ynoqgQNCalWAmXYWQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.40-0",
-        "@github/copilot-darwin-x64": "1.0.40-0",
-        "@github/copilot-linux-arm64": "1.0.40-0",
-        "@github/copilot-linux-x64": "1.0.40-0",
-        "@github/copilot-win32-arm64": "1.0.40-0",
-        "@github/copilot-win32-x64": "1.0.40-0"
+        "@github/copilot-darwin-arm64": "1.0.40-1",
+        "@github/copilot-darwin-x64": "1.0.40-1",
+        "@github/copilot-linux-arm64": "1.0.40-1",
+        "@github/copilot-linux-x64": "1.0.40-1",
+        "@github/copilot-win32-arm64": "1.0.40-1",
+        "@github/copilot-win32-x64": "1.0.40-1"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.40-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-0.tgz",
-      "integrity": "sha512-l905DiMvOB7Jn5MAkS+iEQcM99hmJHQ5yrKaGJ9OteVWBCcxPEO5ctnRYFdeq4NHL+9OnAzJzNc0kwScOAUCzg==",
+      "version": "1.0.40-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-1.tgz",
+      "integrity": "sha512-DSArBmv1A6BstJs23QgXzes7B8Hu+sz4Ccqh1NhY/4NPfxck1rD2v61ZWz8kdwpgTdjP6lWSZ5nLWdi9Go+PhA==",
       "cpu": [
         "arm64"
       ],
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.40-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-0.tgz",
-      "integrity": "sha512-e/Dtc1CjZ5SpNLdtY7vHxzH3hhNKfiMJdyp/2UY/6rzXsSPfbw9xZL01nUBbZt0aYj2FbPBDMTyfqoh5weUSww==",
+      "version": "1.0.40-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-1.tgz",
+      "integrity": "sha512-fTOL2XChDSsPc/q//mIFlq47ABNgyUKqz1+ix5oxloE9RlT1YpD7v3O+dqU/tmdxXwMTfQqgZsYglRY/nna3yw==",
       "cpu": [
         "x64"
       ],
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.40-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-0.tgz",
-      "integrity": "sha512-fR/gVUXFpjwojNf3Pg5lH2vrb8q0Gghv6RK6xx1QS6pEBdPTMGeoPxQVqSSB6dZCR/X3dkK1tIZ5IGnuABDHbA==",
+      "version": "1.0.40-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-1.tgz",
+      "integrity": "sha512-+aon/9kAxgGlxLZrxzwUrNO1G/eUIhhEB6W4u1sMs2GwXjANrDr6WIsp056dOnU2TY9oEnn8vWTJQSIwyFlGHQ==",
       "cpu": [
         "arm64"
       ],
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.40-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-0.tgz",
-      "integrity": "sha512-vDfE5Cxgg+BealbxBjqa0MUrLGJF+zT+XygMFgWXi/4ESVpRvvAet8rUoLeL+7Lgg6QRlS+UMPWfWL6ZAoSp5w==",
+      "version": "1.0.40-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-1.tgz",
+      "integrity": "sha512-p44TeuI01EpizsJmQX0W21f7pPXyTvrXYkv/5W1GgCiNEP4HKLG9rdgdIEtqaIMnXFKssxpGF45+hJuz0iep5g==",
       "cpu": [
         "x64"
       ],
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.40-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-0.tgz",
-      "integrity": "sha512-7aEo1CZ5476lWRtfcym0TX1DhH5l9+PKENHPOr8vfziHKeNlWYkXHVTo7OGIUnCAwIetbCQRyf92nnaFhG/8Jw==",
+      "version": "1.0.40-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-1.tgz",
+      "integrity": "sha512-nrbMh1qc8VWL1KU2N+VdQ2M+4jiGlugApIFNUbfywnUITktWEpQ62Jqf2YQlrMr51f1F1fjSE/YBuDW6InzzYg==",
       "cpu": [
         "arm64"
       ],
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.40-0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-0.tgz",
-      "integrity": "sha512-egnoilEO6TS0qSexe+A26GUSyfeinaqXJRTYL4Qr6eVgAfFhCEpCJtK/gHIZmlDXnq2ex3jGrVvz9+ZIp+JSoA==",
+      "version": "1.0.40-1",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-1.tgz",
+      "integrity": "sha512-n5qmzAn4OKbdHJeOmdt4eUA7XWSUOmNSJUtRswKVqgCxrmMOR/0FXCPzVS0gAJn+UEj9ApHulC6G09HR5Nhp7Q==",
       "cpu": [
         "x64"
       ],

--- a/test/harness/package-lock.json
+++ b/test/harness/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@github/copilot": "^1.0.40-1",
+        "@github/copilot": "^1.0.40-3",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@types/node": "^25.3.3",
         "openai": "^6.17.0",
@@ -462,27 +462,27 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.40-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-1.tgz",
-      "integrity": "sha512-jdohe7CcjlmbNR0bnL/uAbaYDtmqZnHcHo3t/ZspVb9vo7+yk7AdTc4AF4TpV7M/tCKc+ynoqgQNCalWAmXYWQ==",
+      "version": "1.0.40-3",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-3.tgz",
+      "integrity": "sha512-bgvE59bJFsT/tN2CvMR7f5a6NH1tWxYTl9skVrRDk4YS6ZcFP0bclYg/NMDR8D5sfQYngdNN8vxmv85eB8rPVA==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.40-1",
-        "@github/copilot-darwin-x64": "1.0.40-1",
-        "@github/copilot-linux-arm64": "1.0.40-1",
-        "@github/copilot-linux-x64": "1.0.40-1",
-        "@github/copilot-win32-arm64": "1.0.40-1",
-        "@github/copilot-win32-x64": "1.0.40-1"
+        "@github/copilot-darwin-arm64": "1.0.40-3",
+        "@github/copilot-darwin-x64": "1.0.40-3",
+        "@github/copilot-linux-arm64": "1.0.40-3",
+        "@github/copilot-linux-x64": "1.0.40-3",
+        "@github/copilot-win32-arm64": "1.0.40-3",
+        "@github/copilot-win32-x64": "1.0.40-3"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.40-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-1.tgz",
-      "integrity": "sha512-DSArBmv1A6BstJs23QgXzes7B8Hu+sz4Ccqh1NhY/4NPfxck1rD2v61ZWz8kdwpgTdjP6lWSZ5nLWdi9Go+PhA==",
+      "version": "1.0.40-3",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-3.tgz",
+      "integrity": "sha512-QRVt15j3azPs8foceUfwT8COnR5DULOhc+5hUp8UgSJagNGEMv8zwVPYoWiJyeApeLdERDeqBF6M6MHHbMjD+A==",
       "cpu": [
         "arm64"
       ],
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.40-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-1.tgz",
-      "integrity": "sha512-fTOL2XChDSsPc/q//mIFlq47ABNgyUKqz1+ix5oxloE9RlT1YpD7v3O+dqU/tmdxXwMTfQqgZsYglRY/nna3yw==",
+      "version": "1.0.40-3",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-3.tgz",
+      "integrity": "sha512-8P2EBAtxjLfk8mG2DR9laWeX6WT4WkrHG+FcTciTNwzRy5YqaFAommwd+nc8I7ddktZvzgQEz8tdM8SAlQ2d2A==",
       "cpu": [
         "x64"
       ],
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.40-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-1.tgz",
-      "integrity": "sha512-+aon/9kAxgGlxLZrxzwUrNO1G/eUIhhEB6W4u1sMs2GwXjANrDr6WIsp056dOnU2TY9oEnn8vWTJQSIwyFlGHQ==",
+      "version": "1.0.40-3",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-3.tgz",
+      "integrity": "sha512-ItrOgrQ/2QKsrcUHvcSs/y/4HVypzNNFNF/0vL/30yDy89w+5z3hzydZ0uAyMHwf//sWJauAWdkQYmZqaSjT2A==",
       "cpu": [
         "arm64"
       ],
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.40-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-1.tgz",
-      "integrity": "sha512-p44TeuI01EpizsJmQX0W21f7pPXyTvrXYkv/5W1GgCiNEP4HKLG9rdgdIEtqaIMnXFKssxpGF45+hJuz0iep5g==",
+      "version": "1.0.40-3",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-3.tgz",
+      "integrity": "sha512-WwRaJeqy+Ywx8XCKH1X/joLK1xbi6MLwWU+ZnRosr8pkvoLnewlBZRVT3dkxkPYvnTIn/PBJKjhtC2lgptbrTg==",
       "cpu": [
         "x64"
       ],
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.40-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-1.tgz",
-      "integrity": "sha512-nrbMh1qc8VWL1KU2N+VdQ2M+4jiGlugApIFNUbfywnUITktWEpQ62Jqf2YQlrMr51f1F1fjSE/YBuDW6InzzYg==",
+      "version": "1.0.40-3",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-3.tgz",
+      "integrity": "sha512-B/JvunL2xFJ6xGLppTehIotaEqEaWOYg+P929rpx90FG2GdsR5oQ5zVHTiMJWX6YFqmW+Kwc5utCMUj7MjDmQQ==",
       "cpu": [
         "arm64"
       ],
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.40-1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-1.tgz",
-      "integrity": "sha512-n5qmzAn4OKbdHJeOmdt4eUA7XWSUOmNSJUtRswKVqgCxrmMOR/0FXCPzVS0gAJn+UEj9ApHulC6G09HR5Nhp7Q==",
+      "version": "1.0.40-3",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-3.tgz",
+      "integrity": "sha512-80ZFwdKzpRTVjq3MHMU6LjsWjYlVEyI0+rFiM/5s5EmbQDvSnXt4vLT4O+UTbQs+YSi5jRLtm4Q6QkIChE7AWQ==",
       "cpu": [
         "x64"
       ],

--- a/test/harness/package-lock.json
+++ b/test/harness/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@github/copilot": "^1.0.39",
+        "@github/copilot": "^1.0.40-0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@types/node": "^25.3.3",
         "openai": "^6.17.0",
@@ -462,27 +462,27 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.39.tgz",
-      "integrity": "sha512-AY0VPYf6QQm88wUcOav2B36iedWKBUaMegKRxxY2uIHESiU6HueEuQR/n7D3U2UdD0zLox3jFRjYbZAsr2CgkQ==",
+      "version": "1.0.40-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.40-0.tgz",
+      "integrity": "sha512-KIrRqPOCGPcYUq09wvi66qUi5YMFTH5z9fOEzo1BuyLFVQqUen0TtRk0mpbhG6TxArLPqosBY8nDXOdc+NqKKw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.39",
-        "@github/copilot-darwin-x64": "1.0.39",
-        "@github/copilot-linux-arm64": "1.0.39",
-        "@github/copilot-linux-x64": "1.0.39",
-        "@github/copilot-win32-arm64": "1.0.39",
-        "@github/copilot-win32-x64": "1.0.39"
+        "@github/copilot-darwin-arm64": "1.0.40-0",
+        "@github/copilot-darwin-x64": "1.0.40-0",
+        "@github/copilot-linux-arm64": "1.0.40-0",
+        "@github/copilot-linux-x64": "1.0.40-0",
+        "@github/copilot-win32-arm64": "1.0.40-0",
+        "@github/copilot-win32-x64": "1.0.40-0"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.39.tgz",
-      "integrity": "sha512-E8WfNL43NMzMTDDpCiYikaEmYCMAr6mz8LHrJtkaFuVXVkBr/q2NI3hAtwHFy8M11Fac/MeIe3/VEymWwwh3kw==",
+      "version": "1.0.40-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.40-0.tgz",
+      "integrity": "sha512-l905DiMvOB7Jn5MAkS+iEQcM99hmJHQ5yrKaGJ9OteVWBCcxPEO5ctnRYFdeq4NHL+9OnAzJzNc0kwScOAUCzg==",
       "cpu": [
         "arm64"
       ],
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.39.tgz",
-      "integrity": "sha512-0zbC4lDVX7l8Wvq+JSCMjO0xTN69nWLejTBCl3Ev5bP6P+/7wPURcUvZKoHEaXxOULQ3AGj0DwZNAsvvQkA/6Q==",
+      "version": "1.0.40-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.40-0.tgz",
+      "integrity": "sha512-e/Dtc1CjZ5SpNLdtY7vHxzH3hhNKfiMJdyp/2UY/6rzXsSPfbw9xZL01nUBbZt0aYj2FbPBDMTyfqoh5weUSww==",
       "cpu": [
         "x64"
       ],
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.39.tgz",
-      "integrity": "sha512-x88FuByweJlHlAmUZXjq4JlmtqgoM57Fe7nXzQkGr2Y5wnc2EDydBzFYEOlYDSWozQreimaJIm0KEMAA5T8/Fg==",
+      "version": "1.0.40-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.40-0.tgz",
+      "integrity": "sha512-fR/gVUXFpjwojNf3Pg5lH2vrb8q0Gghv6RK6xx1QS6pEBdPTMGeoPxQVqSSB6dZCR/X3dkK1tIZ5IGnuABDHbA==",
       "cpu": [
         "arm64"
       ],
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.39.tgz",
-      "integrity": "sha512-ssahg8r7a0VCsHVXPRmFFXx70xNAxaTM2SZfG7qPRfFB2OM8gHrW26F2oikTklDF6D+A2MfSAMpzJLBUZbPnhw==",
+      "version": "1.0.40-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.40-0.tgz",
+      "integrity": "sha512-vDfE5Cxgg+BealbxBjqa0MUrLGJF+zT+XygMFgWXi/4ESVpRvvAet8rUoLeL+7Lgg6QRlS+UMPWfWL6ZAoSp5w==",
       "cpu": [
         "x64"
       ],
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.39.tgz",
-      "integrity": "sha512-hhBWGZQIywbp6MBxlqMX2GSmHqtUAOGwpo9b0igscecL4i0kz89QNasC+mKiN+zFEHP6I8gggOu87XPI17Io8Q==",
+      "version": "1.0.40-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.40-0.tgz",
+      "integrity": "sha512-7aEo1CZ5476lWRtfcym0TX1DhH5l9+PKENHPOr8vfziHKeNlWYkXHVTo7OGIUnCAwIetbCQRyf92nnaFhG/8Jw==",
       "cpu": [
         "arm64"
       ],
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.39.tgz",
-      "integrity": "sha512-0ehlMtBiwKjmfEY3hVZggdn7qrmPMC8ueBQv/b+6UY3SMRS/M/1Y7xkOCwG84NvJsktdSsk3SlQnE2LbkTVpSA==",
+      "version": "1.0.40-0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.40-0.tgz",
+      "integrity": "sha512-egnoilEO6TS0qSexe+A26GUSyfeinaqXJRTYL4Qr6eVgAfFhCEpCJtK/gHIZmlDXnq2ex3jGrVvz9+ZIp+JSoA==",
       "cpu": [
         "x64"
       ],

--- a/test/harness/package.json
+++ b/test/harness/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@github/copilot": "^1.0.40-0",
+    "@github/copilot": "^1.0.40-1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/node": "^25.3.3",
     "openai": "^6.17.0",

--- a/test/harness/package.json
+++ b/test/harness/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@github/copilot": "^1.0.39",
+    "@github/copilot": "^1.0.40-0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/node": "^25.3.3",
     "openai": "^6.17.0",

--- a/test/harness/package.json
+++ b/test/harness/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@github/copilot": "^1.0.40-1",
+    "@github/copilot": "^1.0.40-3",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/node": "^25.3.3",
     "openai": "^6.17.0",

--- a/test/scenarios/bundling/container-proxy/Dockerfile
+++ b/test/scenarios/bundling/container-proxy/Dockerfile
@@ -16,4 +16,4 @@ RUN chmod +x /usr/local/bin/copilot
 
 EXPOSE 3000
 
-ENTRYPOINT ["copilot", "--headless", "--port", "3000", "--bind", "0.0.0.0", "--auth-token-env", "GITHUB_TOKEN"]
+ENTRYPOINT ["copilot", "--headless", "--port", "3000", "--host", "0.0.0.0", "--auth-token-env", "GITHUB_TOKEN"]

--- a/test/scenarios/bundling/container-proxy/README.md
+++ b/test/scenarios/bundling/container-proxy/README.md
@@ -15,7 +15,7 @@ Run the Copilot CLI inside a Docker container with a simple proxy on the host th
 │                    │  Docker Container        │       │
 │                    │  Copilot CLI             │       │
 │                    │  --port 3000 --headless  │       │
-│                    │  --bind 0.0.0.0          │       │
+│                    │  --host 0.0.0.0          │       │
 │                    │  --auth-token-env        │       │
 │                    └────────────┬─────────────┘       │
 │                                │                     │

--- a/vlang/src/client.v
+++ b/vlang/src/client.v
@@ -132,6 +132,28 @@ pub fn (mut c CopilotClient) get_models() ![]ModelInfo {
 	return json.decode([]ModelInfo, result)
 }
 
+// get_foreground_session_id retrieves the current foreground session ID.
+pub fn (mut c CopilotClient) get_foreground_session_id() !string {
+	raw := c.transport.send_request('session.getForeground', '{}')!
+	result := parse_response_result(raw)!
+	decoded := json.decode(map[string]string, result) or {
+		return error('failed to decode foreground session response: ${err}')
+	}
+	session_id := decoded['sessionId'] or { return error('no sessionId in response') }
+	return session_id
+}
+
+// set_foreground_session_id sets the foreground session to the given ID.
+pub fn (mut c CopilotClient) set_foreground_session_id(session_id string) ! {
+	mut params := map[string]string{}
+	params['"sessionId"'] = '"${session_id}"'
+	raw := c.transport.send_request('session.setForeground', build_params(params))!
+	result := parse_response_result(raw)!
+	if !result.contains('"success":true') && !result.contains('"success": true') {
+		return error('Failed to set foreground session: ${result}')
+	}
+}
+
 // --- private helpers ---
 
 fn (mut c CopilotClient) connect_to_server() ! {

--- a/zig/src/client.zig
+++ b/zig/src/client.zig
@@ -217,6 +217,27 @@ pub const CopilotClient = struct {
         return try self.transport.?.sendRequest("session.getMetadata", .{ .object = params });
     }
 
+    /// Get the foreground session ID.
+    pub fn getForegroundSessionId(self: *CopilotClient) SdkError!JsonValue {
+        if (self.state != .connected) return SdkError.NotConnected;
+        return try self.transport.?.sendRequest("session.getForeground", .{ .object = std.json.ObjectMap.init(self.allocator) });
+    }
+
+    /// Set the foreground session ID.
+    pub fn setForegroundSessionId(self: *CopilotClient, session_id: []const u8) SdkError!void {
+        if (self.state != .connected) return SdkError.NotConnected;
+        var params = std.json.ObjectMap.init(self.allocator);
+        defer params.deinit();
+        params.put("sessionId", .{ .string = session_id }) catch return SdkError.AllocationFailed;
+        const result = try self.transport.?.sendRequest("session.setForeground", .{ .object = params });
+        if (result == .object) {
+            if (result.object.get("success")) |sv| {
+                if (sv == .bool and sv.bool) return;
+            }
+        }
+        return SdkError.RequestFailed;
+    }
+
     /// Get the current connection state.
     pub fn getState(self: *const CopilotClient) ConnectionState {
         return self.state;


### PR DESCRIPTION
## What's in this PR

### Upstream sync (5 commits from github/copilot-sdk)
- **Replace StreamJsonRpc with custom JSON-RPC implementation in .NET SDK** (#1170) - major refactor
- **Document \--host\ for non-loopback headless connections** (#1174)
- Update @github/copilot to 1.0.40-3 (#1182, #1177, #1171)

### Ported to all 36 additional SDKs
- \getForegroundSessionId()\ and \setForegroundSessionId()\ methods added to all SDKs that were missing them (20 SDKs: C, R, Perl, Shell, Elixir, Haskell, MATLAB, Ada, Obj-C, F#, Julia, COBOL, OCaml, Zig, Nim, D, Crystal, Tcl, Solidity, V)

### Other
- Added star CTA to README
- Added no-co-author rule to copilot instructions
- Resolved .gitignore merge conflict (kept both upstream and local entries)

### Testing
- Node SDK unit tests: 58/69 passed, 1 skipped (remaining are long-running E2E)